### PR TITLE
add poolside laguna models + free-tier backoff + <think> parsing

### DIFF
--- a/inputs/model_mappings.yml
+++ b/inputs/model_mappings.yml
@@ -90,6 +90,10 @@ models:
     gemma-4-31b: "google/gemma-4-31b-it"
     qwen3.6-plus: "qwen/qwen3.6-plus"
 
+    # Poolside models
+    laguna-m.1: "poolside/laguna-m.1:free"
+    laguna-xs.2: "poolside/laguna-xs.2:free"
+
   non_thinking:
     # OpenAI standard models
     gpt4: "openai/gpt-4"

--- a/src/connections_eval/adapters/openrouter_adapter.py
+++ b/src/connections_eval/adapters/openrouter_adapter.py
@@ -59,7 +59,13 @@ def extract_provider_slug(model: str) -> Optional[str]:
     return None
 
 
-@retry_with_backoff(max_retries=5, base_delay=2.0, exceptions=(requests.RequestException,))
+def _chat_base_delay(messages: List[Dict], model: str, timeout: int = 300, provider: Optional[str] = None) -> float:
+    # Free-tier endpoints (model IDs ending in `:free`) hit aggressive rate limits;
+    # double the base delay so the exponential schedule actually clears their cooldown.
+    return 4.0 if model.endswith(":free") else 2.0
+
+
+@retry_with_backoff(max_retries=5, base_delay=_chat_base_delay, exceptions=(requests.RequestException,))
 def chat(messages: List[Dict], model: str, timeout: int = 300, provider: Optional[str] = None) -> Dict:
     """
     Call OpenRouter Chat Completions API.

--- a/src/connections_eval/core.py
+++ b/src/connections_eval/core.py
@@ -787,11 +787,11 @@ class ConnectionsGame:
         """Parse response into list of words, handling structured XML format."""
         import re
 
-        # Strip <thinking> blocks first so that any <guess> examples
+        # Strip <thinking>/<think> blocks first so that any <guess> examples
         # inside reasoning don't get picked up by the guess regex.
-        # Also handle unclosed <thinking> tags (truncated responses).
-        cleaned = re.sub(r'<thinking>.*?</thinking>', '', response, flags=re.IGNORECASE | re.DOTALL)
-        cleaned = re.sub(r'<thinking>.*', '', cleaned, flags=re.IGNORECASE | re.DOTALL)
+        # Also handle unclosed tags (truncated responses).
+        cleaned = re.sub(r'<think(?:ing)?>.*?</think(?:ing)?>', '', response, flags=re.IGNORECASE | re.DOTALL)
+        cleaned = re.sub(r'<think(?:ing)?>.*', '', cleaned, flags=re.IGNORECASE | re.DOTALL)
 
         # First try to extract from <guess> tags
         guess_match = re.search(r'<guess>(.*?)</guess>', cleaned, re.IGNORECASE | re.DOTALL)
@@ -826,7 +826,7 @@ class ConnectionsGame:
             'confidence': ''
         }
 
-        thinking_match = re.search(r'<thinking>(.*?)</thinking>', response, re.IGNORECASE | re.DOTALL)
+        thinking_match = re.search(r'<think(?:ing)?>(.*?)</think(?:ing)?>', response, re.IGNORECASE | re.DOTALL)
         if thinking_match:
             result['thinking'] = thinking_match.group(1).strip()
 

--- a/src/connections_eval/utils/retry.py
+++ b/src/connections_eval/utils/retry.py
@@ -72,7 +72,7 @@ def _status_code(exc: Exception) -> int | None:
 
 def retry_with_backoff(
     max_retries: int = 3,
-    base_delay: float = 2.0,
+    base_delay: float | Callable[..., float] = 2.0,
     exceptions: tuple = (Exception,)
 ) -> Callable:
     """
@@ -80,12 +80,16 @@ def retry_with_backoff(
 
     - On HTTP 429, honors Retry-After (if present), otherwise falls back to exponential backoff.
     - Adds small jitter (0-0.5s) to spread concurrent retries.
+    - `base_delay` may be a callable receiving the same args/kwargs as the wrapped function,
+      allowing per-call tuning (e.g. larger backoff for free-tier endpoints).
     """
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def wrapper(*args, **kwargs) -> T:
             last_exception: Exception | None = None
             _backoff_state.backoff_sec = 0.0
+
+            bd = base_delay(*args, **kwargs) if callable(base_delay) else base_delay
 
             for attempt in range(max_retries + 1):
                 try:
@@ -97,7 +101,7 @@ def retry_with_backoff(
                         break
 
                     # Default exponential backoff
-                    exp_delay = base_delay * (2 ** attempt)
+                    exp_delay = bd * (2 ** attempt)
 
                     # If 429, prefer Retry-After when available
                     sc = _status_code(e)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -142,7 +142,7 @@ class TestConnectionsGame:
         # Mix of different groups
         result = mock_game._process_guess(game_state, "APPLE, BLUE, FAST, BRIGHT")
 
-        assert result == "INCORRECT. 3 INCORRECT GUESSES REMAINING"
+        assert result == "INCORRECT. 3 INCORRECT GUESSES REMAINING."
         assert game_state.guess_count == 1
         assert game_state.mistake_count == 1
         assert len(game_state.solved_groups) == 0
@@ -181,7 +181,7 @@ class TestConnectionsGame:
         for i in range(4):
             result = mock_game._process_guess(game_state, "APPLE, BLUE, FAST, BRIGHT")
             expected_remaining = 3 - i
-            assert result == f"INCORRECT. {expected_remaining} INCORRECT GUESSES REMAINING"
+            assert result == f"INCORRECT. {expected_remaining} INCORRECT GUESSES REMAINING."
 
             if i == 3:  # 4th mistake
                 assert game_state.finished


### PR DESCRIPTION
## Summary
- Map `laguna-m.1` and `laguna-xs.2` CLI names to `poolside/laguna-m.1:free` / `poolside/laguna-xs.2:free` in `inputs/model_mappings.yml` (under `thinking`).
- Double retry `base_delay` (2s → 4s) for any model ID ending in `:free`. The free-tier rate limit on OpenRouter routinely outlasts the original 2/4/8/16/32s schedule; smoke-testing `laguna-xs.2` exhausted retries after one correct guess.
- Accept `<think>...</think>` in addition to `<thinking>...</thinking>` when parsing model output. `laguna-m.1` emits the shorter form, which produced two `INVALID_RESPONSE`s during the smoke test before the parser found the guess via fallback.
- Fix two pre-existing test assertions in `tests/test_core.py` that were missing the trailing period on `INCORRECT GUESSES REMAINING.` — they were already failing on `main`.

## Test plan
- [x] `uv run pytest` — 45/45 passing
- [x] Smoke test `laguna-m.1` on puzzle 246 — solved (5 guesses, 1 incorrect, 2 invalid prior to `<think>` fix)
- [x] Smoke test `laguna-xs.2` on puzzle 246 — got 1 correct guess before exhausting retries on free-tier 429s (motivated the backoff change)
- [ ] Re-smoke `laguna-xs.2` after merge to confirm doubled backoff lets it complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)