### PR TITLE
Shared AIMD rate limiter for OpenRouter calls

### DIFF
--- a/inputs/rate_limits.yml
+++ b/inputs/rate_limits.yml
@@ -1,0 +1,24 @@
+# Per-model rate-limit policy. The runtime token bucket adapts (AIMD), so
+# `rps` is a starting point — it'll grow toward `rps_max` while requests
+# succeed and halve toward `rps_min` on every 429.
+#
+# Resolution order: exact model id → suffix patterns starting with ":" →
+# prefix patterns ending with "/" → defaults.
+defaults:
+  rps: 8.0          # starting requests per second per model
+  rps_max: 16.0     # ceiling the bucket can climb to
+  rps_min: 0.5      # floor — we never starve completely
+  burst: 8.0        # tokens accumulated when idle (initial bucket size)
+  aimd_step: 0.5    # additive growth per successful request
+  concurrency: 8    # max simultaneous in-flight requests
+
+policies:
+  # Free-tier OpenRouter endpoints share aggressive rate limits across the
+  # whole project — start slow, climb cautiously, throttle hard on 429.
+  ":free":
+    rps: 1.0
+    rps_max: 3.0
+    rps_min: 0.2
+    burst: 1.0
+    aimd_step: 0.1
+    concurrency: 2

--- a/src/connections_eval/adapters/openrouter_adapter.py
+++ b/src/connections_eval/adapters/openrouter_adapter.py
@@ -6,6 +6,7 @@ import os
 import logging
 from typing import Dict, List, Optional, Set
 from ..utils.retry import retry_with_backoff, get_last_backoff_sec
+from ..utils.rate_limiter import get_default as get_rate_limiter
 
 logger = logging.getLogger(__name__)
 
@@ -159,14 +160,35 @@ def chat(messages: List[Dict], model: str, timeout: int = 300, provider: Optiona
             "temperature": 0.0,
         })
     
-    response = requests.post(url, json=payload, headers=headers, timeout=timeout)
-    
+    # Wait our turn at the shared rate limiter before hitting the network.
+    # Each retry attempt acquires a fresh permit so the in-flight cap stays accurate.
+    limiter = get_rate_limiter()
+    limiter.acquire(openrouter_model)
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=timeout)
+    except BaseException:
+        limiter.release(openrouter_model)
+        raise
+
+    # 429 → feed the AIMD signal so the bucket halves before the retry decorator
+    # backs off; all other workers on this model see the new (slower) rate too.
+    if response.status_code == 429:
+        ra_raw = response.headers.get("Retry-After") or response.headers.get("retry-after")
+        try:
+            ra = float(ra_raw) if ra_raw is not None else None
+        except ValueError:
+            ra = None
+        limiter.on_429(openrouter_model, retry_after=ra)
+        limiter.release(openrouter_model)
+        # Let the retry decorator handle the actual sleep + retry loop.
+        response.raise_for_status()
+
     # Check for OpenRouter-specific errors before raising
     if not response.ok:
         try:
             error_data = response.json()
             error_msg = error_data.get("error", {}).get("message", "")
-            
+
             # Check for data policy configuration error
             if "data policy" in error_msg.lower() and response.status_code == 404:
                 logger.error(f"[OpenRouter] Data policy configuration required for model: {openrouter_model}")
@@ -177,17 +199,26 @@ def chat(messages: List[Dict], model: str, timeout: int = 300, provider: Optiona
                 )
                 error = requests.HTTPError(detailed_msg)
                 error.response = response
+                limiter.release(openrouter_model)
                 raise error
         except requests.HTTPError:
-            # Re-raise our custom error
+            limiter.release(openrouter_model)
             raise
         except (ValueError, KeyError):
             # If we can't parse the error JSON, fall through to default handling
             pass
-    
-    response.raise_for_status()
 
-    response_data = response.json()
+    try:
+        response.raise_for_status()
+    except BaseException:
+        limiter.release(openrouter_model)
+        raise
+
+    try:
+        response_data = response.json()
+    except BaseException:
+        limiter.release(openrouter_model)
+        raise
 
     # OpenRouter occasionally returns HTTP 200 with an error body (no `choices`)
     # when an upstream provider is throttled or misbehaving. Raise as a
@@ -195,7 +226,14 @@ def chat(messages: List[Dict], model: str, timeout: int = 300, provider: Optiona
     # letting a KeyError('choices') escape upstream.
     if not response_data.get("choices"):
         err = response_data.get("error") or response_data
+        # Treat upstream-throttled 200s the same as 429 for the AIMD loop —
+        # the symptom (provider can't serve us right now) is identical.
+        limiter.on_429(openrouter_model, retry_after=None)
+        limiter.release(openrouter_model)
         raise requests.RequestException(f"OpenRouter 200 OK but no 'choices' in body: {err}")
+
+    limiter.on_success(openrouter_model)
+    limiter.release(openrouter_model)
 
     # DEBUG: Log if content is missing but tokens were used
     choice = response_data["choices"][0]

--- a/src/connections_eval/utils/rate_limiter.py
+++ b/src/connections_eval/utils/rate_limiter.py
@@ -1,0 +1,208 @@
+"""Thread-safe AIMD token-bucket rate limiter with concurrency cap.
+
+All worker threads share one limiter per model. Each call to chat():
+  1. Acquires a concurrency permit (BoundedSemaphore).
+  2. Waits for a token to refill in the bucket (rps-paced).
+  3. On 200 → on_success() additively grows rps toward rps_max.
+  4. On 429 → on_429() halves rps (down to rps_min), drains remaining
+     tokens, and honors Retry-After if the provider sent one.
+
+This is the same control loop TCP uses for congestion (AIMD): grow slowly
+while things are fine, back off hard when the network pushes back. It
+self-tunes so a single magic rps value isn't required per provider.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _Bucket:
+    rps: float
+    rps_max: float
+    rps_min: float
+    burst: float
+    aimd_step: float
+    tokens: float = field(init=False)
+    last_refill: float = field(init=False)
+    lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+
+    def __post_init__(self) -> None:
+        self.tokens = self.burst
+        self.last_refill = time.monotonic()
+
+
+@dataclass
+class _Policy:
+    rps: float = 8.0
+    rps_max: float = 16.0
+    rps_min: float = 0.5
+    burst: float = 8.0
+    aimd_step: float = 0.5
+    concurrency: int = 8
+
+
+class RateLimiter:
+    """Per-model AIMD token bucket + concurrency cap, shared across threads."""
+
+    def __init__(self, default_policy: Optional[_Policy] = None) -> None:
+        self._default = default_policy or _Policy()
+        self._policies: Dict[str, _Policy] = {}
+        self._buckets: Dict[str, _Bucket] = {}
+        self._semaphores: Dict[str, threading.BoundedSemaphore] = {}
+        self._lock = threading.Lock()
+
+    def configure(self, model_or_pattern: str, policy: _Policy) -> None:
+        with self._lock:
+            self._policies[model_or_pattern] = policy
+
+    def _resolve_policy(self, model: str) -> _Policy:
+        if model in self._policies:
+            return self._policies[model]
+        # Pattern-match by suffix (":free") or prefix (e.g. "poolside/").
+        for pattern, policy in self._policies.items():
+            if pattern.startswith(":") and model.endswith(pattern):
+                return policy
+            if pattern.endswith("/") and model.startswith(pattern):
+                return policy
+        return self._default
+
+    def _get(self, model: str) -> tuple[_Bucket, threading.BoundedSemaphore]:
+        with self._lock:
+            if model not in self._buckets:
+                policy = self._resolve_policy(model)
+                self._buckets[model] = _Bucket(
+                    rps=policy.rps,
+                    rps_max=policy.rps_max,
+                    rps_min=policy.rps_min,
+                    burst=policy.burst,
+                    aimd_step=policy.aimd_step,
+                )
+                self._semaphores[model] = threading.BoundedSemaphore(policy.concurrency)
+            return self._buckets[model], self._semaphores[model]
+
+    def acquire(self, model: str) -> None:
+        bucket, sem = self._get(model)
+        sem.acquire()
+        try:
+            while True:
+                with bucket.lock:
+                    now = time.monotonic()
+                    elapsed = now - bucket.last_refill
+                    bucket.last_refill = now
+                    bucket.tokens = min(bucket.burst, bucket.tokens + elapsed * bucket.rps)
+                    if bucket.tokens >= 1.0:
+                        bucket.tokens -= 1.0
+                        return
+                    deficit = 1.0 - bucket.tokens
+                    wait = deficit / max(bucket.rps, 1e-3)
+                # Sleep outside the lock so other threads can refill / acquire.
+                time.sleep(min(wait, 1.0))
+        except BaseException:
+            sem.release()
+            raise
+
+    def release(self, model: str) -> None:
+        sem = self._semaphores.get(model)
+        if sem is None:
+            return
+        try:
+            sem.release()
+        except ValueError:
+            # Already at max — happens if a release races with acquire failure cleanup.
+            pass
+
+    def on_success(self, model: str) -> None:
+        bucket, _ = self._get(model)
+        with bucket.lock:
+            new = min(bucket.rps + bucket.aimd_step, bucket.rps_max)
+            if new != bucket.rps:
+                bucket.rps = new
+
+    def on_429(self, model: str, retry_after: Optional[float] = None) -> None:
+        bucket, _ = self._get(model)
+        with bucket.lock:
+            old = bucket.rps
+            bucket.rps = max(bucket.rps / 2.0, bucket.rps_min)
+            bucket.tokens = 0.0
+        logger.warning(
+            f"[ratelimit] 429 on {model}: rps {old:.2f} → {bucket.rps:.2f}"
+            + (f" (Retry-After={retry_after:.1f}s)" if retry_after else "")
+        )
+        if retry_after and retry_after > 0:
+            time.sleep(retry_after)
+
+    def snapshot(self, model: str) -> Dict[str, float]:
+        bucket, _ = self._get(model)
+        with bucket.lock:
+            return {"rps": bucket.rps, "tokens": bucket.tokens, "burst": bucket.burst}
+
+
+# -----------------------------------------------------------------------------
+# Default instance + YAML config loader
+# -----------------------------------------------------------------------------
+
+_default_limiter: Optional[RateLimiter] = None
+_default_lock = threading.Lock()
+
+
+def _load_config_from_yaml(path: Path) -> RateLimiter:
+    import yaml  # type: ignore
+
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+    defaults = raw.get("defaults", {}) or {}
+    policy_default = _Policy(
+        rps=float(defaults.get("rps", 8.0)),
+        rps_max=float(defaults.get("rps_max", defaults.get("rps", 8.0) * 2)),
+        rps_min=float(defaults.get("rps_min", 0.5)),
+        burst=float(defaults.get("burst", defaults.get("rps", 8.0))),
+        aimd_step=float(defaults.get("aimd_step", 0.5)),
+        concurrency=int(defaults.get("concurrency", 8)),
+    )
+    limiter = RateLimiter(default_policy=policy_default)
+    for key, vals in (raw.get("policies") or {}).items():
+        vals = vals or {}
+        limiter.configure(
+            key,
+            _Policy(
+                rps=float(vals.get("rps", policy_default.rps)),
+                rps_max=float(vals.get("rps_max", vals.get("rps", policy_default.rps_max))),
+                rps_min=float(vals.get("rps_min", policy_default.rps_min)),
+                burst=float(vals.get("burst", vals.get("rps", policy_default.burst))),
+                aimd_step=float(vals.get("aimd_step", policy_default.aimd_step)),
+                concurrency=int(vals.get("concurrency", policy_default.concurrency)),
+            ),
+        )
+    return limiter
+
+
+def get_default() -> RateLimiter:
+    global _default_limiter
+    with _default_lock:
+        if _default_limiter is None:
+            cfg = Path(__file__).resolve().parents[3] / "inputs" / "rate_limits.yml"
+            if cfg.exists():
+                try:
+                    _default_limiter = _load_config_from_yaml(cfg)
+                except Exception as e:
+                    logger.warning(f"[ratelimit] failed to load {cfg}: {e}; using defaults")
+                    _default_limiter = RateLimiter()
+            else:
+                _default_limiter = RateLimiter()
+        return _default_limiter
+
+
+def reset_default_for_tests() -> None:
+    """Reset the module-level limiter — only call from tests."""
+    global _default_limiter
+    with _default_lock:
+        _default_limiter = None

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,100 @@
+"""Tests for the AIMD rate limiter."""
+
+import threading
+import time
+
+import pytest
+
+from connections_eval.utils.rate_limiter import RateLimiter, _Policy
+
+
+def test_acquire_paces_calls_at_configured_rps():
+    rl = RateLimiter(default_policy=_Policy(rps=10.0, burst=1.0, concurrency=4))
+    model = "test/model"
+    # First acquire is immediate (burst=1).
+    t0 = time.monotonic()
+    rl.acquire(model)
+    rl.release(model)
+    # Second acquire should wait ~0.1s for token refill (rps=10).
+    rl.acquire(model)
+    rl.release(model)
+    elapsed = time.monotonic() - t0
+    assert elapsed >= 0.08, f"expected pacing delay, got {elapsed:.3f}s"
+
+
+def test_on_429_halves_rps_and_floors_at_min():
+    rl = RateLimiter(default_policy=_Policy(rps=8.0, rps_min=1.0, concurrency=4))
+    model = "test/model"
+    rl.acquire(model); rl.release(model)
+    assert rl.snapshot(model)["rps"] == pytest.approx(8.0)
+    rl.on_429(model)
+    assert rl.snapshot(model)["rps"] == pytest.approx(4.0)
+    rl.on_429(model)
+    assert rl.snapshot(model)["rps"] == pytest.approx(2.0)
+    rl.on_429(model)
+    assert rl.snapshot(model)["rps"] == pytest.approx(1.0)
+    rl.on_429(model)
+    # Should not drop below floor.
+    assert rl.snapshot(model)["rps"] == pytest.approx(1.0)
+
+
+def test_on_success_grows_rps_up_to_max():
+    rl = RateLimiter(default_policy=_Policy(rps=2.0, rps_max=5.0, aimd_step=1.0, concurrency=4))
+    model = "test/model"
+    rl.acquire(model); rl.release(model)
+    rl.on_success(model)
+    assert rl.snapshot(model)["rps"] == pytest.approx(3.0)
+    for _ in range(10):
+        rl.on_success(model)
+    assert rl.snapshot(model)["rps"] == pytest.approx(5.0)
+
+
+def test_concurrency_cap_limits_in_flight():
+    rl = RateLimiter(default_policy=_Policy(rps=100.0, burst=100.0, concurrency=2))
+    model = "test/model"
+    in_flight = []
+    in_flight_lock = threading.Lock()
+    peak = [0]
+
+    def worker():
+        rl.acquire(model)
+        with in_flight_lock:
+            in_flight.append(1)
+            peak[0] = max(peak[0], len(in_flight))
+        time.sleep(0.05)
+        with in_flight_lock:
+            in_flight.pop()
+        rl.release(model)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+    assert peak[0] <= 2, f"concurrency cap of 2 was exceeded: peak={peak[0]}"
+
+
+def test_pattern_resolution_picks_free_suffix():
+    rl = RateLimiter(default_policy=_Policy(rps=10.0, concurrency=8))
+    rl.configure(":free", _Policy(rps=1.0, concurrency=2))
+    rl.acquire("poolside/laguna-m.1:free"); rl.release("poolside/laguna-m.1:free")
+    rl.acquire("openai/gpt-5"); rl.release("openai/gpt-5")
+    assert rl.snapshot("poolside/laguna-m.1:free")["rps"] == pytest.approx(1.0)
+    assert rl.snapshot("openai/gpt-5")["rps"] == pytest.approx(10.0)
+
+
+def test_acquire_release_balanced_under_exception():
+    rl = RateLimiter(default_policy=_Policy(rps=100.0, burst=100.0, concurrency=1))
+    model = "test/model"
+    rl.acquire(model)
+    rl.release(model)
+    # If acquire/release leaked, this second pair would block forever; bound it with a timer.
+    done = threading.Event()
+
+    def go():
+        rl.acquire(model)
+        rl.release(model)
+        done.set()
+
+    t = threading.Thread(target=go)
+    t.start()
+    t.join(timeout=1.0)
+    assert done.is_set(), "rate limiter leaked a permit across acquire/release"


### PR DESCRIPTION
## Summary
- Add a process-wide AIMD token-bucket + concurrency cap shared across worker threads, keyed by model
- Wire it into `openrouter_adapter.chat()` so every call acquires a permit, feeds `on_success`/`on_429`, and converges to whatever rate the provider actually allows
- Configure `:free` endpoints to start at `rps=1, concurrency=2` (vs the default `rps=8, concurrency=8` for paid tiers)

## Why
The recent `laguna-m.1` run lost 4 puzzles outright to thundering-herd 429s: 8 worker threads each running their own retry/backoff against the same OpenRouter API key, with no shared awareness of how hard the fleet was hitting the endpoint. By the time each worker exhausted its 6 retries, the puzzle was dead. AIMD (the same control loop TCP uses) self-tunes the rate without us picking magic numbers per provider — grow gently while things work, halve hard on every 429.

## What changed
- `src/connections_eval/utils/rate_limiter.py` — new module. `RateLimiter` exposes `acquire`/`release`/`on_success`/`on_429`/`snapshot`. Pattern resolution: exact model → `:suffix` → `prefix/` → defaults.
- `src/connections_eval/adapters/openrouter_adapter.py` — `chat()` now wraps the HTTP call with the limiter. 429s and upstream-throttled 200s both feed `on_429`. Each retry attempt re-acquires so the in-flight cap stays accurate.
- `inputs/rate_limits.yml` — declarative policy. Defaults match today's effective behavior for paid models; `:free` gets throttled.
- `tests/test_rate_limiter.py` — pacing, AIMD halve/grow with floor/ceiling, concurrency cap under contention, pattern resolution, acquire/release balance.

## Test plan
- [x] `uv run pytest tests/` — 51 tests pass (45 prior + 6 new)
- [ ] Re-run `laguna-m.1` against this branch and confirm all 20 puzzles reach a terminal state (vs the 16/20 in the prior run)
- [ ] Spot-check a paid-tier model run to confirm performance hasn't regressed (defaults preserve prior behavior)

## Rollback
Self-contained branch — revert the merge commit to back out the change. The new `inputs/rate_limits.yml` is read at first use; deleting it falls back to defaults that match prior behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)