### PR TITLE
Throttle deepseek/deepseek-v4-pro to avoid 429s

### DIFF
--- a/inputs/rate_limits.yml
+++ b/inputs/rate_limits.yml
@@ -22,3 +22,14 @@ policies:
     burst: 1.0
     aimd_step: 0.1
     concurrency: 2
+
+  # deepseek-v4-pro returns 429s under the default 8-rps / 8-concurrency load.
+  # Start in the middle ground between :free and defaults; AIMD will climb back
+  # if the upstream is healthier than we assume.
+  "deepseek/deepseek-v4-pro":
+    rps: 2.0
+    rps_max: 6.0
+    rps_min: 0.3
+    burst: 2.0
+    aimd_step: 0.2
+    concurrency: 3


### PR DESCRIPTION
## Summary
- Add a per-model rate-limit policy for `deepseek/deepseek-v4-pro` so it starts at `rps=2, concurrency=3` instead of the default `rps=8, concurrency=8` that was triggering 429s and making the model unusable

## Why
Follow-up to #14. The defaults work for most paid endpoints, but `deepseek-v4-pro` 429s under that load. AIMD is allowed to climb to `rps_max=6` if the upstream turns out to be healthier than this conservative starting point.

## Test plan
- [x] `uv run pytest tests/` — 51 tests pass
- [x] Confirmed policy resolution: `deepseek/deepseek-v4-pro` → rps=2, others unchanged
- [x] Smoke run on `deepseek-v4` against canonical 20-puzzle set (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)