### PR TITLE
Add granite-4.1-8b and grok-4.3 thinking models

### DIFF
--- a/inputs/model_mappings.yml
+++ b/inputs/model_mappings.yml
@@ -27,6 +27,7 @@ models:
     grok4: "x-ai/grok-4"
     grok4-fast: "x-ai/grok-4-fast"
     grok-4.20: "x-ai/grok-4.20"
+    grok-4.3: "x-ai/grok-4.3"
     grok-code: "x-ai/grok-code-fast-1"
     
     # Google reasoning models
@@ -66,6 +67,9 @@ models:
     # Xiaomi reasoning models
     mimo-v2-omni: "xiaomi/mimo-v2-omni"
     mimo-v2-pro: "xiaomi/mimo-v2-pro"
+
+    # IBM reasoning models
+    granite-4.1-8b: "ibm-granite/granite-4.1-8b"
 
     # Other reasoning models
     ring-1t: "inclusionai/ring-1t"


### PR DESCRIPTION
## Summary
- Add `granite-4.1-8b` → `ibm-granite/granite-4.1-8b` (new IBM section)
- Add `grok-4.3` → `x-ai/grok-4.3`

## Test plan
- [x] Smoke test `granite-4.1-8b` on puzzle 246 — ran cleanly (0/1 solved, 20.3s, \$0.0005)
- [x] Smoke test `grok-4.3` on puzzle 246 — 1/1 solved, 427.7s, \$0.062

🤖 Generated with [Claude Code](https://claude.com/claude-code)