### PR TITLE
feat: send session_id for sticky routing to enable caching on non-pinned models

### DIFF
--- a/src/connections_eval/adapters/openrouter_adapter.py
+++ b/src/connections_eval/adapters/openrouter_adapter.py
@@ -60,14 +60,16 @@ def extract_provider_slug(model: str) -> Optional[str]:
     return None
 
 
-def _chat_base_delay(messages: List[Dict], model: str, timeout: int = 300, provider: Optional[str] = None) -> float:
+def _chat_base_delay(messages: List[Dict], model: str, timeout: int = 300,
+                     provider: Optional[str] = None, **_kwargs) -> float:
     # Free-tier endpoints (model IDs ending in `:free`) hit aggressive rate limits;
     # double the base delay so the exponential schedule actually clears their cooldown.
     return 4.0 if model.endswith(":free") else 2.0
 
 
 @retry_with_backoff(max_retries=5, base_delay=_chat_base_delay, exceptions=(requests.RequestException,))
-def chat(messages: List[Dict], model: str, timeout: int = 300, provider: Optional[str] = None) -> Dict:
+def chat(messages: List[Dict], model: str, timeout: int = 300, provider: Optional[str] = None,
+         session_id: Optional[str] = None) -> Dict:
     """
     Call OpenRouter Chat Completions API.
 
@@ -78,6 +80,11 @@ def chat(messages: List[Dict], model: str, timeout: int = 300, provider: Optiona
         provider: Optional provider slug to pin requests to (e.g., 'anthropic').
             When set, forces OpenRouter to route to this provider with no fallbacks,
             enabling prompt caching across calls.
+        session_id: Optional stable identifier shared by all calls in one
+            conversation. OpenRouter uses it as the sticky-routing key, pinning
+            every request in the session to the same upstream provider — from the
+            first call, before any cache hit. This is the only caching lever for
+            cloaked/third-party-hosted models that have no pinnable provider slug.
 
     Returns:
         Raw API response JSON
@@ -147,6 +154,12 @@ def chat(messages: List[Dict], model: str, timeout: int = 300, provider: Optiona
             "order": [provider],
             "allow_fallbacks": False,
         }
+
+    # Sticky-routing key. Keeps all calls in one puzzle conversation on the same
+    # upstream provider so prompt caching can take effect — especially for cloaked
+    # or third-party-hosted models that have no pinnable provider slug above.
+    if session_id:
+        payload["session_id"] = session_id
 
     # Handle different model types
     if is_thinking_model:

--- a/src/connections_eval/core.py
+++ b/src/connections_eval/core.py
@@ -411,8 +411,16 @@ class ConnectionsGame:
         log_summary(self.logger, summary)
         return summary
 
-    def _run_puzzle_ai(self, puzzle: Puzzle, model_name: str, rng: random.Random) -> PuzzleResult:
-        """Run a single puzzle with AI model."""
+    def _run_puzzle_ai(self, puzzle: Puzzle, model_name: str, rng: random.Random,
+                       attempt: Optional[int] = None) -> PuzzleResult:
+        """Run a single puzzle with AI model.
+
+        attempt: optional trial index. The normal eval path runs each puzzle once
+            per run_id, so task_id is already unique. Ranking re-runs the same
+            puzzle under one run_id, so callers pass the trial index to keep each
+            attempt's sticky-routing session_id distinct — otherwise repeated
+            trials would share a routing session and lose independence.
+        """
         model_id = self.MODEL_CONFIG[model_name]
         adapter = openrouter_adapter
         pinned_provider = adapter.extract_provider_slug(model_id)
@@ -439,6 +447,9 @@ class ConnectionsGame:
         total_upstream_cost = 0.0
         total_backoff_sec = 0.0
         task_id = f"T{puzzle.id}:{self.run_id}"
+        # Sticky-routing key shared by every turn of this puzzle. Append the trial
+        # index when ranking so repeated attempts get independent routing sessions.
+        session_id = task_id if attempt is None else f"{task_id}:a{attempt}"
         final_state_emitted = False
 
         state.start_time = time.time()
@@ -462,7 +473,7 @@ class ConnectionsGame:
                     # provider (sticky routing) so caching also works for cloaked /
                     # non-pinnable models that have no provider slug.
                     response = adapter.chat(
-                        messages, model_id, provider=pinned_provider, session_id=task_id
+                        messages, model_id, provider=pinned_provider, session_id=session_id
                     )
 
                     backoff_sec = float(response.pop("_backoff_sec", 0.0))
@@ -919,7 +930,7 @@ class ConnectionsGame:
 
         for i in range(runs):
             run_rng = random.Random(self.seed + puzzle.id + i)
-            stats = self._run_puzzle_ai(puzzle, model_name, run_rng)
+            stats = self._run_puzzle_ai(puzzle, model_name, run_rng, attempt=i)
 
             if stats.won:
                 wins += 1

--- a/src/connections_eval/core.py
+++ b/src/connections_eval/core.py
@@ -457,8 +457,13 @@ class ConnectionsGame:
             with Timer() as timer:
                 try:
                     # Pin to provider on all calls to enable prompt caching
-                    # (requires provider + cache_control + prefix >= 1024 tokens)
-                    response = adapter.chat(messages, model_id, provider=pinned_provider)
+                    # (requires provider + cache_control + prefix >= 1024 tokens).
+                    # session_id keeps every turn of this puzzle on one upstream
+                    # provider (sticky routing) so caching also works for cloaked /
+                    # non-pinnable models that have no provider slug.
+                    response = adapter.chat(
+                        messages, model_id, provider=pinned_provider, session_id=task_id
+                    )
 
                     backoff_sec = float(response.pop("_backoff_sec", 0.0))
                     total_backoff_sec += backoff_sec

--- a/src/connections_eval/core.py
+++ b/src/connections_eval/core.py
@@ -912,7 +912,9 @@ class ConnectionsGame:
         Public API that accepts a puzzle_id. Delegates to _rank_puzzle().
         """
         if self.logger is None:
-            self.run_id = f"rank_{model_name}"
+            # Timestamp the base id so each rank invocation gets its own run_id
+            # (and OpenRouter session key), matching the eval `run` path.
+            self.run_id = f"rank_{datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%S')}_{model_name}"
             self.logger = setup_logger(self.log_path, self.run_id, verbose=self.verbose)
 
         puzzle_map = {p.id: p for p in self.puzzles}
@@ -958,7 +960,9 @@ class ConnectionsGame:
         """
         # Ensure logger is set up for ranking
         if self.logger is None:
-            self.run_id = f"rank_{model_name}"
+            # Timestamp the base id so each rank invocation gets its own run_id
+            # (and OpenRouter session key), matching the eval `run` path.
+            self.run_id = f"rank_{datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%S')}_{model_name}"
             self.logger = setup_logger(self.log_path, self.run_id, verbose=self.verbose)
 
         all_puzzles = list(self.puzzles)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -473,6 +473,30 @@ class TestRankSessionIsolation:
             game._rank_puzzle(puzzle, runs=3, model_name=next(iter(game.MODEL_CONFIG)))
         assert attempts == [0, 1, 2]
 
+    def test_rank_run_id_is_timestamped(self):
+        """A fresh rank invocation builds a timestamped run_id (not the static
+        rank_{model} form) so session keys don't recur across invocations."""
+        import re
+
+        def fake_run(puzzle, model_name, rng, attempt=None):
+            return PuzzleResult(
+                won=False, guess_count=0, mistake_count=0, invalid_count=0,
+                solved_groups=[], time_sec=0.0, total_tokens=0,
+            )
+
+        # Fresh game: logger is None so the rank entrypoint assigns run_id.
+        game = ConnectionsGame(self._INPUTS, Path("logs"))
+        puzzle_id = game.puzzles[0].id
+        model_name = next(iter(game.MODEL_CONFIG))
+        with patch("connections_eval.core.setup_logger", return_value=MagicMock()), \
+             patch.object(game, "_run_puzzle_ai", side_effect=fake_run):
+            game.rank_puzzle(puzzle_id, runs=1, model_name=model_name)
+        assert game.run_id != f"rank_{model_name}"
+        assert re.fullmatch(
+            rf"rank_\d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}-\d{{2}}-\d{{2}}_{re.escape(model_name)}",
+            game.run_id,
+        )
+
 
 class TestUtilities:
     """Test utility functions."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -362,6 +362,46 @@ class TestChatProviderParam:
         payload = mock_post.call_args[1]["json"]
         assert payload["provider"] == {"order": ["openai"], "allow_fallbacks": False}
 
+    @patch("connections_eval.adapters.openrouter_adapter.requests.post")
+    @patch("connections_eval.adapters.openrouter_adapter._get_api_key", return_value="test-key")
+    def test_chat_without_session_id(self, mock_key, mock_post):
+        """session_id key should not appear when session_id is None."""
+        from connections_eval.adapters.openrouter_adapter import chat
+
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        mock_post.return_value = mock_response
+
+        chat([{"role": "user", "content": "test"}], "openrouter/fusion")
+
+        payload = mock_post.call_args[1]["json"]
+        assert "session_id" not in payload
+
+    @patch("connections_eval.adapters.openrouter_adapter.requests.post")
+    @patch("connections_eval.adapters.openrouter_adapter._get_api_key", return_value="test-key")
+    def test_chat_with_session_id(self, mock_key, mock_post):
+        """session_id should be set top-level for sticky routing on cloaked models."""
+        from connections_eval.adapters.openrouter_adapter import chat
+
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        mock_post.return_value = mock_response
+
+        chat([{"role": "user", "content": "test"}], "openrouter/fusion", session_id="T314:run1")
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["session_id"] == "T314:run1"
+        # Cloaked model has no pinnable slug, so no provider order is forced.
+        assert "provider" not in payload
+
 
 class TestUtilities:
     """Test utility functions."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 """Tests for core game logic."""
 
+import random
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -401,6 +402,76 @@ class TestChatProviderParam:
         assert payload["session_id"] == "T314:run1"
         # Cloaked model has no pinnable slug, so no provider order is forced.
         assert "provider" not in payload
+
+
+class TestRankSessionIsolation:
+    """session_id passed to the adapter must be unique per ranking attempt so
+    repeated trials of one puzzle don't share a sticky-routing session."""
+
+    _INPUTS = Path(__file__).resolve().parent.parent / "inputs"
+
+    def _build_game(self):
+        game = ConnectionsGame(self._INPUTS, Path("logs"))
+        game.run_id = "rank_test-model"
+        game.logger = MagicMock()
+        return game
+
+    def _capture_session_ids(self, attempt):
+        """Run one puzzle with a mocked adapter and return the session_ids the
+        game passed to adapter.chat. The mock returns an unparseable guess so the
+        game ends after MAX_INVALID turns regardless of which puzzle is chosen."""
+        captured = []
+
+        def fake_chat(messages, model_id, provider=None, session_id=None):
+            captured.append(session_id)
+            return {
+                "choices": [{"message": {"content": "no valid guess here"},
+                             "finish_reason": "stop"}],
+                "usage": {},
+            }
+
+        with patch("connections_eval.core.cl"), \
+             patch("connections_eval.core.openrouter_adapter") as mock_adapter:
+            mock_adapter.chat.side_effect = fake_chat
+            mock_adapter.extract_provider_slug.return_value = None  # cloaked model
+            game = self._build_game()
+            puzzle = game.puzzles[0]
+            model_name = next(iter(game.MODEL_CONFIG))
+            game._run_puzzle_ai(puzzle, model_name, random.Random(0), attempt=attempt)
+        return captured
+
+    def test_normal_path_session_id_is_task_id(self):
+        """attempt=None (normal eval) leaves session_id as the bare task_id."""
+        sessions = self._capture_session_ids(attempt=None)
+        assert sessions  # game actually called the adapter
+        assert all(s.endswith(":rank_test-model") for s in sessions)
+        assert all(":a" not in s for s in sessions)
+
+    def test_rank_attempts_get_distinct_sessions(self):
+        """Different attempts produce different session_ids; within an attempt
+        every turn shares one session (so caching can still work per trial)."""
+        a0 = self._capture_session_ids(attempt=0)
+        a1 = self._capture_session_ids(attempt=1)
+        assert len(set(a0)) == 1 and a0[0].endswith(":a0")
+        assert len(set(a1)) == 1 and a1[0].endswith(":a1")
+        assert a0[0] != a1[0]
+
+    def test_rank_passes_incrementing_attempt_index(self):
+        """_rank_puzzle hands _run_puzzle_ai a distinct attempt index per trial."""
+        attempts = []
+
+        def fake_run(puzzle, model_name, rng, attempt=None):
+            attempts.append(attempt)
+            return PuzzleResult(
+                won=False, guess_count=0, mistake_count=0, invalid_count=0,
+                solved_groups=[], time_sec=0.0, total_tokens=0,
+            )
+
+        game = self._build_game()
+        puzzle = game.puzzles[0]
+        with patch.object(game, "_run_puzzle_ai", side_effect=fake_run):
+            game._rank_puzzle(puzzle, runs=3, model_name=next(iter(game.MODEL_CONFIG)))
+        assert attempts == [0, 1, 2]
 
 
 class TestUtilities:


### PR DESCRIPTION
## Summary
Adds an optional `session_id` to the OpenRouter adapter, set to the per-puzzle `task_id`, so every turn of a puzzle conversation pins to the same upstream provider (OpenRouter **sticky routing**) from the first call — before any cache hit. This is the only prompt-caching lever available to cloaked / third-party-hosted models that have no pinnable provider slug (the `_PROVIDER_SLUG_MAP` only covers anthropic/openai/google/xai).

## Changes
- `openrouter_adapter.chat()`: new optional `session_id` param, written to the top-level payload (`payload["session_id"]`).
- `_chat_base_delay()`: accept `**_kwargs` so the retry decorator can forward the new kwarg.
- `core.py`: pass `session_id=task_id` (`T{puzzle.id}:{run_id}`) — stable across all turns of a puzzle.
- Tests: added `session_id` present/absent payload assertions. Full suite green (53 passed).

## Verification
- Unit tests confirm `session_id` lands top-level in the request body.
- Live re-run of `fusion` on puzzle 314: `session_id` is sent correctly. **However, `fusion` still reports `cached_tokens=0`** — its hidden backend does not support/report prompt caching through OpenRouter, which no client-side change can fix. The change still benefits non-pinned *auto-caching* providers and is harmless where it doesn't help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)