### PR TITLE
Refactor: deduplicate classic and one-shot puzzle runners (#23)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -18,7 +18,7 @@
 - **Generate leaderboards**: `uv run python scripts/create_results_mviz.py` (docs/index.html = one-shot, docs/classic.html = classic multi-turn)
 
 ## Architecture
-- **Core**: `src/connections_eval/core.py` - Game logic, puzzle handling, metrics
+- **Core**: `src/connections_eval/core.py` - Game logic, puzzle handling, metrics. Both runners (`_run_puzzle_ai` classic, `_run_puzzle_oneshot_ai` one-shot) share `_run_exchange()` for transport + accounting + telemetry (including the API-error path) and supply only a per-mode verdict callback returning a `_Verdict`; keep mode-specific result strings and log fields in those callbacks
 - **CLI**: `src/connections_eval/cli.py` - Typer-based command interface
 - **Adapters**: `src/connections_eval/adapters/openrouter_adapter.py` - Unified OpenRouter integration for 200+ AI models
 - **Utils**: `src/connections_eval/utils/` - Timing, tokens, logging, retry utilities

--- a/src/connections_eval/core.py
+++ b/src/connections_eval/core.py
@@ -4,10 +4,10 @@ import random
 import time
 import yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, Any
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from .utils.timing import Timer
 from .utils.tokens import count_tokens, extract_token_usage, extract_cost_info, extract_cache_info
@@ -138,6 +138,82 @@ class GameState:
     won: bool
     start_time: Optional[float]
     end_time: Optional[float]
+
+
+@dataclass
+class _ExchangeTotals:
+    """Token, cost, cache and backoff totals accumulated across one puzzle's exchanges."""
+    tokens: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cached_tokens: int = 0
+    cost: float = 0.0
+    upstream_cost: float = 0.0
+    backoff_sec: float = 0.0
+    token_method: str = "APPROXIMATE"
+
+    def as_result_fields(self) -> Dict[str, Any]:
+        """Accounting fields for a PuzzleResult, keyed by its field names."""
+        return {
+            "total_tokens": self.tokens,
+            "total_prompt_tokens": self.prompt_tokens,
+            "total_completion_tokens": self.completion_tokens,
+            "token_count_method": self.token_method,
+            "total_cached_tokens": self.cached_tokens,
+            "total_cost": self.cost,
+            "total_upstream_cost": self.upstream_cost,
+            "total_backoff_sec": self.backoff_sec,
+        }
+
+
+@dataclass
+class _PuzzleRunContext:
+    """Transport and telemetry identifiers shared by every exchange of one puzzle."""
+    model_name: str
+    model_id: str
+    pinned_provider: Optional[str]
+    task_id: str
+    session_id: str
+    totals: _ExchangeTotals = field(default_factory=_ExchangeTotals)
+
+
+@dataclass
+class _Verdict:
+    """Mode-specific scoring of one exchange, produced by a verdict callback.
+
+    result: result string recorded in the exchange log and telemetry (in classic
+        mode it is also fed back to the model as the next user turn).
+    guess_text: value for the exchange log's `guess` field; None keeps the
+        `<guess>` block parsed out of the response.
+    log_extra: extra exchange-log fields, merged in after `result`.
+    telemetry_extra: extra fields for the controllog completion-event payload.
+    """
+    result: str
+    guess_text: Optional[str] = None
+    log_extra: Dict[str, Any] = field(default_factory=dict)
+    telemetry_extra: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class _Exchange:
+    """Outcome of one model exchange (see ConnectionsGame._run_exchange)."""
+    ok: bool
+    content: str = ""
+    verdict: Optional[_Verdict] = None
+    # True when the API-error path already moved the task WIP -> FAILED
+    failed_state_emitted: bool = False
+
+
+@dataclass
+class _OneshotOutcome:
+    """Game-logic outcome of a one-shot submission, filled by its verdict callback."""
+    won: bool = False
+    score: int = 0
+    groups_correct: int = 0
+    trap_bonus: int = 0
+    mistake_count: int = 0
+    invalid_count: int = 0
+    solved_groups: List[str] = field(default_factory=list)
 
 
 class ConnectionsGame:
@@ -486,9 +562,9 @@ class ConnectionsGame:
         log_summary(self.logger, summary)
         return summary
 
-    def _run_puzzle_ai(self, puzzle: Puzzle, model_name: str, rng: random.Random,
-                       attempt: Optional[int] = None) -> PuzzleResult:
-        """Run a single puzzle with AI model.
+    def _begin_puzzle(self, puzzle: Puzzle, model_name: str,
+                      attempt: Optional[int]) -> _PuzzleRunContext:
+        """Resolve a puzzle's transport identifiers and emit its NEW -> WIP move.
 
         attempt: optional trial index. The normal eval path runs each puzzle once
             per run_id, so task_id is already unique. Ranking re-runs the same
@@ -497,8 +573,272 @@ class ConnectionsGame:
             trials would share a routing session and lose independence.
         """
         model_id = self.MODEL_CONFIG[model_name]
-        adapter = openrouter_adapter
-        pinned_provider = adapter.extract_provider_slug(model_id)
+        task_id = f"T{puzzle.id}:{self.run_id}"
+        ctx = _PuzzleRunContext(
+            model_name=model_name,
+            model_id=model_id,
+            pinned_provider=openrouter_adapter.extract_provider_slug(model_id),
+            task_id=task_id,
+            # Sticky-routing key shared by every turn of this puzzle.
+            session_id=task_id if attempt is None else f"{task_id}:a{attempt}",
+        )
+
+        try:
+            cl.state_move(
+                task_id=task_id, from_="NEW", to="WIP",
+                project_id="connections_eval",
+                agent_id="agent:connections_eval",
+                run_id=self.run_id,
+                payload={"puzzle_id": puzzle.id},
+            )
+        except Exception:
+            pass
+
+        return ctx
+
+    def _finish_puzzle(self, puzzle: Puzzle, ctx: _PuzzleRunContext, won: bool) -> None:
+        """Emit the final WIP -> DONE/FAILED transition for a puzzle."""
+        try:
+            cl.state_move(
+                task_id=ctx.task_id, from_="WIP", to=("DONE" if won else "FAILED"),
+                project_id="connections_eval",
+                agent_id="agent:connections_eval",
+                run_id=self.run_id,
+                payload={"puzzle_id": puzzle.id},
+            )
+        except Exception:
+            pass
+
+    def _extract_content(self, response: Dict) -> str:
+        """Extract the assistant text from a response, with reasoning fallbacks."""
+        choice = response["choices"][0]
+        message = choice["message"]
+        content = message.get("content", "")
+        finish_reason = choice.get("finish_reason", "unknown")
+
+        # Handle empty content (thinking models may put output in reasoning fields)
+        if not content or content.strip() == "":
+            self.logger.warning(f"Empty content field. finish_reason: {finish_reason}")
+            self.logger.warning(f"Message keys: {list(message.keys())}")
+            self.logger.warning(f"Full message: {message}")
+            self.logger.warning(f"Full choice: {choice}")
+
+            if finish_reason == "length":
+                self.logger.error("Response truncated due to token limit!")
+
+            if "reasoning" in message:
+                self.logger.info("Found reasoning field, using it as content")
+                content = message["reasoning"]
+            elif "extended_thinking" in message:
+                self.logger.info("Found extended_thinking field, using it as content")
+                content = message["extended_thinking"]
+
+        return content.strip() if content else ""
+
+    def _accumulate_token_usage(
+        self, response: Dict, messages: List[Dict], content: str,
+        totals: _ExchangeTotals
+    ) -> Tuple[Optional[int], Optional[int]]:
+        """Add this exchange's token usage to totals.
+
+        Returns the API-reported (prompt, completion) counts, which are None when
+        the response carried no usage block — the totals then take approximate
+        counts, but the logged numbers stay honest about being absent.
+        """
+        prompt_tokens, completion_tokens, method = extract_token_usage(response)
+        if prompt_tokens and completion_tokens:
+            totals.prompt_tokens += prompt_tokens
+            totals.completion_tokens += completion_tokens
+            totals.tokens += prompt_tokens + completion_tokens
+            totals.token_method = method
+        else:
+            prompt_text = " ".join([msg["content"] for msg in messages])
+            approx_prompt = count_tokens(prompt_text)
+            approx_completion = count_tokens(content)
+            totals.prompt_tokens += approx_prompt
+            totals.completion_tokens += approx_completion
+            totals.tokens += approx_prompt + approx_completion
+        return prompt_tokens, completion_tokens
+
+    def _run_exchange(
+        self,
+        ctx: _PuzzleRunContext,
+        puzzle: Puzzle,
+        messages: List[Dict],
+        verdict_fn: Callable[[str, Dict[str, str]], _Verdict],
+        guess_index_fn: Callable[[], int],
+        error_payload_extra: Optional[Dict[str, Any]] = None,
+    ) -> _Exchange:
+        """Run one model exchange: transport, accounting, scoring, telemetry.
+
+        Calls the model, accumulates tokens/cost/cache/backoff into ctx.totals,
+        hands the response to verdict_fn for mode-specific scoring, then logs the
+        exchange and emits controllog telemetry. The API-error path lives here
+        too: it logs an API_ERROR exchange, emits `model_response_error` plus the
+        WIP -> FAILED state move, and returns _Exchange(ok=False). Non-retryable
+        errors (e.g. insufficient credits) propagate to the caller instead.
+
+        verdict_fn runs inside the same try as the API call, so a scoring failure
+        is reported the same way a transport failure is.
+
+        guess_index_fn is a callback rather than a value because classic mode
+        logs the guess index *after* the verdict has incremented it.
+
+        error_payload_extra adds fields to the `model_response_error` payload.
+        """
+        with Timer() as timer:
+            try:
+                # Pin to provider on all calls to enable prompt caching
+                # (requires provider + cache_control + prefix >= 1024 tokens).
+                # session_id keeps every turn of this puzzle on one upstream
+                # provider (sticky routing) so caching also works for cloaked /
+                # non-pinnable models that have no provider slug.
+                response = openrouter_adapter.chat(
+                    messages, ctx.model_id, provider=ctx.pinned_provider,
+                    session_id=ctx.session_id, reasoning_effort=self.reasoning_effort,
+                )
+
+                backoff_sec = float(response.pop("_backoff_sec", 0.0))
+                ctx.totals.backoff_sec += backoff_sec
+
+                content = self._extract_content(response)
+                structured_response = self._parse_structured_response(content)
+
+                # Track tokens
+                prompt_tokens, completion_tokens = self._accumulate_token_usage(
+                    response, messages, content, ctx.totals
+                )
+
+                # Track costs and cache info
+                cost, upstream_cost = extract_cost_info(response)
+                if cost is not None:
+                    ctx.totals.cost += cost
+                if upstream_cost is not None:
+                    ctx.totals.upstream_cost += upstream_cost
+
+                cache_info = extract_cache_info(response)
+                if cache_info.get("cached_tokens"):
+                    ctx.totals.cached_tokens += cache_info["cached_tokens"]
+
+                verdict = verdict_fn(content, structured_response)
+
+            except Exception as e:
+                if getattr(e, "non_retryable", False):
+                    raise
+                elapsed_ms = int((time.time() - timer.start_time) * 1000) if timer.start_time else 0
+                backoff_sec = get_last_backoff_sec()
+                ctx.totals.backoff_sec += backoff_sec
+                backoff_ms = int(backoff_sec * 1000)
+                inference_ms = max(0, elapsed_ms - backoff_ms)
+                guess_index = guess_index_fn()
+
+                log_exchange(self.logger, {
+                    "run_id": self.run_id,
+                    "model": ctx.model_name,
+                    "puzzle_id": puzzle.id,
+                    "guess_index": guess_index,
+                    "request": messages[-1]["content"],
+                    "response": str(e),
+                    "latency_ms": elapsed_ms,
+                    "backoff_ms": backoff_ms,
+                    "inference_ms": inference_ms,
+                    "prompt_tokens": None,
+                    "completion_tokens": None,
+                    "result": "API_ERROR"
+                })
+
+                self.logger.error(f"API call failed: {str(e)}")
+                failed_state_emitted = False
+                try:
+                    # Diagnostic event: stash error text in response_text and elapsed in wall_ms
+                    # because the events.payload_json STRUCT schema has no `error`/`latency_ms` fields,
+                    # and unknown fields are silently dropped at ingest.
+                    cl.event(
+                        kind="model_response_error",
+                        actor={"agent_id": "agent:connections_eval", "task_id": ctx.task_id},
+                        run_id=self.run_id,
+                        payload={
+                            "model": ctx.model_name,
+                            "puzzle_id": puzzle.id,
+                            "guess_index": guess_index,
+                            "phase": "error",
+                            "wall_ms": elapsed_ms,
+                            "response_text": str(e),
+                            **(error_payload_extra or {}),
+                        },
+                        project_id="connections_eval",
+                        source="runtime",
+                    )
+                    # Canonical state transition — must be a state_move event so the
+                    # renderer (and any other state_move consumer) sees WIP → FAILED.
+                    cl.state_move(
+                        task_id=ctx.task_id, from_="WIP", to="FAILED",
+                        project_id="connections_eval",
+                        agent_id="agent:connections_eval",
+                        run_id=self.run_id,
+                        payload={"puzzle_id": puzzle.id, "reason": "api_error"},
+                    )
+                    failed_state_emitted = True
+                except Exception:
+                    pass
+
+                return _Exchange(ok=False, failed_state_emitted=failed_state_emitted)
+
+        # Log exchange
+        backoff_ms = int(backoff_sec * 1000)
+        inference_ms = max(0, timer.elapsed_ms - backoff_ms)
+        guess_index = guess_index_fn()
+        exchange_data = {
+            "run_id": self.run_id,
+            "model": ctx.model_name,
+            "puzzle_id": puzzle.id,
+            "guess_index": guess_index,
+            "request": messages[-1]["content"],
+            "response": content,
+            "thinking": structured_response.get('thinking', ''),
+            "guess": (structured_response.get('guess', '') if verdict.guess_text is None
+                      else verdict.guess_text),
+            "confidence": structured_response.get('confidence', ''),
+            "latency_ms": timer.elapsed_ms,
+            "backoff_ms": backoff_ms,
+            "inference_ms": inference_ms,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "result": verdict.result,
+            **verdict.log_extra,
+        }
+
+        if cost is not None:
+            exchange_data["cost"] = cost
+        if upstream_cost is not None:
+            exchange_data["upstream_cost"] = upstream_cost
+        if cache_info.get("cached_tokens") is not None:
+            exchange_data["cached_tokens"] = cache_info["cached_tokens"]
+        if cache_info.get("cache_discount") is not None:
+            exchange_data["cache_discount"] = cache_info["cache_discount"]
+
+        log_exchange(self.logger, exchange_data)
+
+        self._emit_model_telemetry(
+            ctx.task_id, ctx.model_id, puzzle.id, guess_index,
+            messages[-1]["content"], content,
+            prompt_tokens, completion_tokens, timer.elapsed_ms,
+            cost, upstream_cost, verdict.result,
+            backoff_ms=backoff_ms,
+            extra_payload=verdict.telemetry_extra,
+        )
+
+        return _Exchange(ok=True, content=content, verdict=verdict)
+
+    def _run_puzzle_ai(self, puzzle: Puzzle, model_name: str, rng: random.Random,
+                       attempt: Optional[int] = None) -> PuzzleResult:
+        """Run a single puzzle with AI model (classic multi-turn mode).
+
+        Guesses one group at a time, feeding each result back to the model until
+        it solves the puzzle or exhausts its mistakes/invalid responses.
+        See _begin_puzzle for the `attempt` semantics.
+        """
+        ctx = self._begin_puzzle(puzzle, model_name, attempt)
 
         state = GameState(
             puzzle=puzzle,
@@ -513,221 +853,35 @@ class ConnectionsGame:
         )
 
         messages = self._build_initial_messages(puzzle, rng)
-        total_tokens = 0
-        total_prompt_tokens = 0
-        total_completion_tokens = 0
-        token_method = "APPROXIMATE"
-        total_cached_tokens = 0
-        total_cost = 0.0
-        total_upstream_cost = 0.0
-        total_backoff_sec = 0.0
-        task_id = f"T{puzzle.id}:{self.run_id}"
-        # Sticky-routing key shared by every turn of this puzzle. Append the trial
-        # index when ranking so repeated attempts get independent routing sessions.
-        session_id = task_id if attempt is None else f"{task_id}:a{attempt}"
         final_state_emitted = False
 
         state.start_time = time.time()
-        try:
-            cl.state_move(
-                task_id=task_id, from_="NEW", to="WIP",
-                project_id="connections_eval",
-                agent_id="agent:connections_eval",
-                run_id=self.run_id,
-                payload={"puzzle_id": puzzle.id},
-            )
-        except Exception:
-            pass
 
         while not state.finished:
-            with Timer() as timer:
-                try:
-                    # Pin to provider on all calls to enable prompt caching
-                    # (requires provider + cache_control + prefix >= 1024 tokens).
-                    # session_id keeps every turn of this puzzle on one upstream
-                    # provider (sticky routing) so caching also works for cloaked /
-                    # non-pinnable models that have no provider slug.
-                    response = adapter.chat(
-                        messages, model_id, provider=pinned_provider, session_id=session_id,
-                        reasoning_effort=self.reasoning_effort,
-                    )
-
-                    backoff_sec = float(response.pop("_backoff_sec", 0.0))
-                    total_backoff_sec += backoff_sec
-
-                    choice = response["choices"][0]
-                    message = choice["message"]
-                    content = message.get("content", "")
-                    finish_reason = choice.get("finish_reason", "unknown")
-
-                    # Handle empty content (thinking models may put output in reasoning fields)
-                    if not content or content.strip() == "":
-                        self.logger.warning(f"Empty content field. finish_reason: {finish_reason}")
-                        self.logger.warning(f"Message keys: {list(message.keys())}")
-                        self.logger.warning(f"Full message: {message}")
-                        self.logger.warning(f"Full choice: {choice}")
-
-                        if finish_reason == "length":
-                            self.logger.error("Response truncated due to token limit!")
-
-                        if "reasoning" in message:
-                            self.logger.info("Found reasoning field, using it as content")
-                            content = message["reasoning"]
-                        elif "extended_thinking" in message:
-                            self.logger.info("Found extended_thinking field, using it as content")
-                            content = message["extended_thinking"]
-
-                    content = content.strip() if content else ""
-                    structured_response = self._parse_structured_response(content)
-
-                    # Track tokens
-                    prompt_tokens, completion_tokens, method = extract_token_usage(response)
-                    if prompt_tokens and completion_tokens:
-                        total_prompt_tokens += prompt_tokens
-                        total_completion_tokens += completion_tokens
-                        total_tokens += prompt_tokens + completion_tokens
-                        token_method = method
-                    else:
-                        prompt_text = " ".join([msg["content"] for msg in messages])
-                        approx_prompt = count_tokens(prompt_text)
-                        approx_completion = count_tokens(content)
-                        total_prompt_tokens += approx_prompt
-                        total_completion_tokens += approx_completion
-                        total_tokens += approx_prompt + approx_completion
-
-                    # Track costs and cache info
-                    cost, upstream_cost = extract_cost_info(response)
-                    if cost is not None:
-                        total_cost += cost
-                    if upstream_cost is not None:
-                        total_upstream_cost += upstream_cost
-
-                    cache_info = extract_cache_info(response)
-                    if cache_info.get("cached_tokens"):
-                        total_cached_tokens += cache_info["cached_tokens"]
-
-                    result = self._process_guess(state, content)
-
-                except Exception as e:
-                    if getattr(e, "non_retryable", False):
-                        raise
-                    elapsed_ms = int((time.time() - timer.start_time) * 1000) if timer.start_time else 0
-                    backoff_sec = get_last_backoff_sec()
-                    total_backoff_sec += backoff_sec
-                    backoff_ms = int(backoff_sec * 1000)
-                    inference_ms = max(0, elapsed_ms - backoff_ms)
-
-                    log_exchange(self.logger, {
-                        "run_id": self.run_id,
-                        "model": model_name,
-                        "puzzle_id": puzzle.id,
-                        "guess_index": state.guess_count,
-                        "request": messages[-1]["content"],
-                        "response": str(e),
-                        "latency_ms": elapsed_ms,
-                        "backoff_ms": backoff_ms,
-                        "inference_ms": inference_ms,
-                        "prompt_tokens": None,
-                        "completion_tokens": None,
-                        "result": "API_ERROR"
-                    })
-
-                    self.logger.error(f"API call failed: {str(e)}")
-                    try:
-                        # Diagnostic event: stash error text in response_text and elapsed in wall_ms
-                        # because the events.payload_json STRUCT schema has no `error`/`latency_ms` fields,
-                        # and unknown fields are silently dropped at ingest.
-                        cl.event(
-                            kind="model_response_error",
-                            actor={"agent_id": "agent:connections_eval", "task_id": task_id},
-                            run_id=self.run_id,
-                            payload={
-                                "model": model_name,
-                                "puzzle_id": puzzle.id,
-                                "guess_index": state.guess_count,
-                                "phase": "error",
-                                "wall_ms": elapsed_ms,
-                                "response_text": str(e),
-                            },
-                            project_id="connections_eval",
-                            source="runtime",
-                        )
-                        # Canonical state transition — must be a state_move event so the
-                        # renderer (and any other state_move consumer) sees WIP → FAILED.
-                        cl.state_move(
-                            task_id=task_id, from_="WIP", to="FAILED",
-                            project_id="connections_eval",
-                            agent_id="agent:connections_eval",
-                            run_id=self.run_id,
-                            payload={"puzzle_id": puzzle.id, "reason": "api_error"},
-                        )
-                        final_state_emitted = True
-                    except Exception:
-                        pass
-                    state.finished = True
-                    break
-
-            # Log exchange
-            backoff_ms = int(backoff_sec * 1000)
-            inference_ms = max(0, timer.elapsed_ms - backoff_ms)
-            exchange_data = {
-                "run_id": self.run_id,
-                "model": model_name,
-                "puzzle_id": puzzle.id,
-                "guess_index": state.guess_count,
-                "request": messages[-1]["content"],
-                "response": content,
-                "thinking": structured_response.get('thinking', ''),
-                "guess": structured_response.get('guess', ''),
-                "confidence": structured_response.get('confidence', ''),
-                "latency_ms": timer.elapsed_ms,
-                "backoff_ms": backoff_ms,
-                "inference_ms": inference_ms,
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "result": result
-            }
-
-            if cost is not None:
-                exchange_data["cost"] = cost
-            if upstream_cost is not None:
-                exchange_data["upstream_cost"] = upstream_cost
-            if cache_info.get("cached_tokens") is not None:
-                exchange_data["cached_tokens"] = cache_info["cached_tokens"]
-            if cache_info.get("cache_discount") is not None:
-                exchange_data["cache_discount"] = cache_info["cache_discount"]
-
-            log_exchange(self.logger, exchange_data)
-
-            self._emit_model_telemetry(
-                task_id, model_id, puzzle.id, state.guess_count,
-                messages[-1]["content"], content,
-                prompt_tokens, completion_tokens, timer.elapsed_ms,
-                cost, upstream_cost, result,
-                backoff_ms=backoff_ms,
+            exchange = self._run_exchange(
+                ctx, puzzle, messages,
+                verdict_fn=lambda content, structured: _Verdict(
+                    result=self._process_guess(state, content)
+                ),
+                guess_index_fn=lambda: state.guess_count,
             )
 
+            if not exchange.ok:
+                final_state_emitted = exchange.failed_state_emitted
+                state.finished = True
+                break
+
             # Append response and result to conversation
-            messages.append({"role": "assistant", "content": content})
+            messages.append({"role": "assistant", "content": exchange.content})
             if not state.finished:
-                messages.append({"role": "user", "content": result})
+                messages.append({"role": "user", "content": exchange.verdict.result})
 
         state.end_time = time.time()
         time_sec = state.end_time - state.start_time
 
         # Emit final state transition
         if not final_state_emitted:
-            final_state = "DONE" if state.won else "FAILED"
-            try:
-                cl.state_move(
-                    task_id=task_id, from_="WIP", to=final_state,
-                    project_id="connections_eval",
-                    agent_id="agent:connections_eval",
-                    run_id=self.run_id,
-                    payload={"puzzle_id": puzzle.id},
-                )
-            except Exception:
-                pass
+            self._finish_puzzle(puzzle, ctx, won=state.won)
 
         return PuzzleResult(
             won=state.won,
@@ -736,14 +890,7 @@ class ConnectionsGame:
             invalid_count=state.invalid_count,
             solved_groups=list(state.solved_groups),
             time_sec=time_sec,
-            total_tokens=total_tokens,
-            total_prompt_tokens=total_prompt_tokens,
-            total_completion_tokens=total_completion_tokens,
-            token_count_method=token_method,
-            total_cached_tokens=total_cached_tokens,
-            total_cost=total_cost,
-            total_upstream_cost=total_upstream_cost,
-            total_backoff_sec=total_backoff_sec,
+            **ctx.totals.as_result_fields(),
         )
 
     def _run_puzzle_interactive(self, puzzle: Puzzle) -> PuzzleResult:
@@ -831,319 +978,167 @@ class ConnectionsGame:
             token_count_method="N/A",
         )
 
+    def _is_valid_oneshot_submission(self, puzzle: Puzzle, groups: List[List[str]]) -> bool:
+        """Structural validity of a one-shot submission.
+
+        Mirrors _score_oneshot's gate: exactly 4 groups of 4 words that together
+        equal the puzzle's 16 words.
+        """
+        submitted_words = [w for g in groups for w in g]
+        return (
+            len(groups) == 4
+            and all(len(g) == 4 for g in groups)
+            and len(submitted_words) == 16
+            and set(submitted_words) == set(w.upper() for w in puzzle.words)
+        )
+
+    def _matched_group_colors(self, puzzle: Puzzle, groups: List[List[str]]) -> List[str]:
+        """Colors of the puzzle groups a submission got exactly right."""
+        submitted_sets = [set(w.upper() for w in g) for g in groups]
+        return [
+            grp.color for grp in puzzle.groups
+            if set(w.upper() for w in grp.words) in submitted_sets
+        ]
+
+    def _score_oneshot_submission(self, puzzle: Puzzle, content: str,
+                                  puzzle_max: int) -> Tuple[_OneshotOutcome, _Verdict]:
+        """Parse and score a one-shot submission.
+
+        Returns the game-logic outcome plus the verdict that carries its result
+        string and the score fields attached to the log and telemetry.
+        """
+        groups = self._parse_oneshot_response(content)
+        groups_correct, score = self._score_oneshot(puzzle, groups)
+        won = (groups_correct == 4)
+        is_valid = self._is_valid_oneshot_submission(puzzle, groups)
+
+        if not is_valid:
+            # A structurally invalid answer scores 0 overall — the trap
+            # bonus is forfeited along with the base score.
+            invalid_count = 1
+            mistake_count = 0
+            trap_bonus = 0
+            trap_claims = None
+            solved_groups: List[str] = []
+            result = f"ONESHOT_INVALID_MAX_{puzzle_max}"
+        else:
+            invalid_count = 0
+            mistake_count = 4 - groups_correct
+            solved_groups = self._matched_group_colors(puzzle, groups)
+            trap_claims = self._parse_oneshot_traps(content)
+            trap_bonus = self._score_trap_claims(puzzle, trap_claims)
+            score += trap_bonus
+            # MAX carries the per-puzzle ceiling (5 reviewed / 3 unreviewed)
+            # so downstream aggregation doesn't have to guess it.
+            result = f"ONESHOT_SCORE_{score}_GROUPS_{groups_correct}_TRAP_{trap_bonus}_MAX_{puzzle_max}"
+
+        outcome = _OneshotOutcome(
+            won=won,
+            score=score,
+            groups_correct=groups_correct,
+            trap_bonus=trap_bonus,
+            mistake_count=mistake_count,
+            invalid_count=invalid_count,
+            solved_groups=solved_groups,
+        )
+        score_fields = {"score": score, "groups_correct": groups_correct,
+                        "trap_bonus": trap_bonus}
+        verdict = _Verdict(
+            result=result,
+            guess_text=self._extract_oneshot_answer_text(content),
+            log_extra={
+                **score_fields,
+                "trap_claims": ([] if trap_claims is None
+                                else [", ".join(c) for c in trap_claims] or ["N/A"]),
+            },
+            telemetry_extra=score_fields,
+        )
+        return outcome, verdict
+
+    def _extract_oneshot_answer_text(self, content: str) -> str:
+        """Extract the <answer> block for the exchange log's `guess` field.
+
+        Strips thinking blocks first so a decoy <answer> example inside reasoning
+        isn't logged as the guess (scoring already does the same).
+        """
+        import re
+
+        log_cleaned = re.sub(r'<think(?:ing)?>.*?</think(?:ing)?>', '', content, flags=re.IGNORECASE | re.DOTALL)
+        log_cleaned = re.sub(r'<think(?:ing)?>.*', '', log_cleaned, flags=re.IGNORECASE | re.DOTALL)
+        answer_match = re.search(r'<answer>(.*?)</answer>', log_cleaned, re.IGNORECASE | re.DOTALL)
+        return answer_match.group(1).strip() if answer_match else content
+
     def _run_puzzle_oneshot_ai(self, puzzle: Puzzle, model_name: str, rng: random.Random,
                                attempt: Optional[int] = None) -> PuzzleResult:
         """Run a single puzzle in one-shot mode with an AI model.
 
-        Modeled on _run_puzzle_ai but makes a single API call: the model submits
-        all 4 groups at once and there is no feedback loop. Base score 0/1/2/3
-        (perfect = 3) plus a 2-point trap bonus.
-
-        attempt: optional trial index. See _run_puzzle_ai for the session_id
-            rationale — repeated attempts get independent sticky-routing sessions.
+        A single API call: the model submits all 4 groups at once and there is no
+        feedback loop. Base score 0/1/2/3 (perfect = 3) plus a 2-point trap bonus.
+        See _begin_puzzle for the `attempt` semantics.
         """
-        model_id = self.MODEL_CONFIG[model_name]
-        adapter = openrouter_adapter
-        pinned_provider = adapter.extract_provider_slug(model_id)
-
+        ctx = self._begin_puzzle(puzzle, model_name, attempt)
         messages = self._build_initial_messages(puzzle, rng)
-        total_tokens = 0
-        total_prompt_tokens = 0
-        total_completion_tokens = 0
-        token_method = "APPROXIMATE"
-        total_cached_tokens = 0
-        total_cost = 0.0
-        total_upstream_cost = 0.0
-        total_backoff_sec = 0.0
-        task_id = f"T{puzzle.id}:{self.run_id}"
-        # Sticky-routing key. Append the trial index when ranking so repeated
-        # attempts get independent routing sessions.
-        session_id = task_id if attempt is None else f"{task_id}:a{attempt}"
-        final_state_emitted = False
+        puzzle_max = 5 if puzzle.trap_groups is not None else 3
+        outcome = _OneshotOutcome()
 
         start_time = time.time()
-        try:
-            cl.state_move(
-                task_id=task_id, from_="NEW", to="WIP",
-                project_id="connections_eval",
-                agent_id="agent:connections_eval",
-                run_id=self.run_id,
-                payload={"puzzle_id": puzzle.id},
-            )
-        except Exception:
-            pass
 
-        with Timer() as timer:
-            try:
-                # Pin to provider on all calls to enable prompt caching; session_id
-                # keeps this puzzle on one upstream provider (sticky routing).
-                response = adapter.chat(
-                    messages, model_id, provider=pinned_provider, session_id=session_id,
-                    reasoning_effort=self.reasoning_effort,
-                )
+        def verdict_fn(content: str, structured: Dict[str, str]) -> _Verdict:
+            nonlocal outcome
+            outcome, verdict = self._score_oneshot_submission(puzzle, content, puzzle_max)
+            return verdict
 
-                backoff_sec = float(response.pop("_backoff_sec", 0.0))
-                total_backoff_sec += backoff_sec
-
-                choice = response["choices"][0]
-                message = choice["message"]
-                content = message.get("content", "")
-                finish_reason = choice.get("finish_reason", "unknown")
-
-                # Handle empty content (thinking models may put output in reasoning fields)
-                if not content or content.strip() == "":
-                    self.logger.warning(f"Empty content field. finish_reason: {finish_reason}")
-                    self.logger.warning(f"Message keys: {list(message.keys())}")
-                    self.logger.warning(f"Full message: {message}")
-                    self.logger.warning(f"Full choice: {choice}")
-
-                    if finish_reason == "length":
-                        self.logger.error("Response truncated due to token limit!")
-
-                    if "reasoning" in message:
-                        self.logger.info("Found reasoning field, using it as content")
-                        content = message["reasoning"]
-                    elif "extended_thinking" in message:
-                        self.logger.info("Found extended_thinking field, using it as content")
-                        content = message["extended_thinking"]
-
-                content = content.strip() if content else ""
-                structured_response = self._parse_structured_response(content)
-
-                # Track tokens
-                prompt_tokens, completion_tokens, method = extract_token_usage(response)
-                if prompt_tokens and completion_tokens:
-                    total_prompt_tokens += prompt_tokens
-                    total_completion_tokens += completion_tokens
-                    total_tokens += prompt_tokens + completion_tokens
-                    token_method = method
-                else:
-                    prompt_text = " ".join([msg["content"] for msg in messages])
-                    approx_prompt = count_tokens(prompt_text)
-                    approx_completion = count_tokens(content)
-                    total_prompt_tokens += approx_prompt
-                    total_completion_tokens += approx_completion
-                    total_tokens += approx_prompt + approx_completion
-
-                # Track costs and cache info
-                cost, upstream_cost = extract_cost_info(response)
-                if cost is not None:
-                    total_cost += cost
-                if upstream_cost is not None:
-                    total_upstream_cost += upstream_cost
-
-                cache_info = extract_cache_info(response)
-                if cache_info.get("cached_tokens"):
-                    total_cached_tokens += cache_info["cached_tokens"]
-
-                # Parse and score the single submission
-                groups = self._parse_oneshot_response(content)
-                groups_correct, score = self._score_oneshot(puzzle, groups)
-                won = (groups_correct == 4)
-                puzzle_max = 5 if puzzle.trap_groups is not None else 3
-
-                # Structural validity mirrors _score_oneshot's gate: exactly 4
-                # groups of 4 words that together equal the puzzle's 16 words.
-                submitted_words = [w for g in groups for w in g]
-                is_valid = (
-                    len(groups) == 4
-                    and all(len(g) == 4 for g in groups)
-                    and len(submitted_words) == 16
-                    and set(submitted_words) == set(w.upper() for w in puzzle.words)
-                )
-
-                if not is_valid:
-                    # A structurally invalid answer scores 0 overall — the trap
-                    # bonus is forfeited along with the base score.
-                    invalid_count = 1
-                    mistake_count = 0
-                    trap_bonus = 0
-                    trap_claims = None
-                    solved_groups: List[str] = []
-                    result = f"ONESHOT_INVALID_MAX_{puzzle_max}"
-                else:
-                    invalid_count = 0
-                    mistake_count = 4 - groups_correct
-                    # Colors of matched puzzle groups
-                    submitted_sets = [set(w.upper() for w in g) for g in groups]
-                    solved_groups = [
-                        grp.color for grp in puzzle.groups
-                        if set(w.upper() for w in grp.words) in submitted_sets
-                    ]
-                    trap_claims = self._parse_oneshot_traps(content)
-                    trap_bonus = self._score_trap_claims(puzzle, trap_claims)
-                    score += trap_bonus
-                    # MAX carries the per-puzzle ceiling (5 reviewed / 3 unreviewed)
-                    # so downstream aggregation doesn't have to guess it.
-                    result = f"ONESHOT_SCORE_{score}_GROUPS_{groups_correct}_TRAP_{trap_bonus}_MAX_{puzzle_max}"
-
-            except Exception as e:
-                if getattr(e, "non_retryable", False):
-                    raise
-                elapsed_ms = int((time.time() - timer.start_time) * 1000) if timer.start_time else 0
-                backoff_sec = get_last_backoff_sec()
-                total_backoff_sec += backoff_sec
-                backoff_ms = int(backoff_sec * 1000)
-                inference_ms = max(0, elapsed_ms - backoff_ms)
-
-                log_exchange(self.logger, {
-                    "run_id": self.run_id,
-                    "model": model_name,
-                    "puzzle_id": puzzle.id,
-                    "guess_index": 0,
-                    "request": messages[-1]["content"],
-                    "response": str(e),
-                    "latency_ms": elapsed_ms,
-                    "backoff_ms": backoff_ms,
-                    "inference_ms": inference_ms,
-                    "prompt_tokens": None,
-                    "completion_tokens": None,
-                    "result": "API_ERROR"
-                })
-
-                self.logger.error(f"API call failed: {str(e)}")
-                try:
-                    cl.event(
-                        kind="model_response_error",
-                        actor={"agent_id": "agent:connections_eval", "task_id": task_id},
-                        run_id=self.run_id,
-                        payload={
-                            "model": model_name,
-                            "puzzle_id": puzzle.id,
-                            "guess_index": 0,
-                            "phase": "error",
-                            "wall_ms": elapsed_ms,
-                            "response_text": str(e),
-                            # Mode marker: without it, a run whose every call
-                            # errors has no ONESHOT_* completion strings and the
-                            # MotherDuck aggregation would misclassify it as
-                            # classic. MAX carries the per-puzzle score ceiling.
-                            "result": f"ONESHOT_API_ERROR_MAX_{5 if puzzle.trap_groups is not None else 3}",
-                        },
-                        project_id="connections_eval",
-                        source="runtime",
-                    )
-                    cl.state_move(
-                        task_id=task_id, from_="WIP", to="FAILED",
-                        project_id="connections_eval",
-                        agent_id="agent:connections_eval",
-                        run_id=self.run_id,
-                        payload={"puzzle_id": puzzle.id, "reason": "api_error"},
-                    )
-                    final_state_emitted = True
-                except Exception:
-                    pass
-
-                return PuzzleResult(
-                    won=False,
-                    guess_count=0,
-                    mistake_count=0,
-                    invalid_count=0,
-                    solved_groups=[],
-                    time_sec=time.time() - start_time,
-                    total_tokens=0,
-                    total_prompt_tokens=0,
-                    total_completion_tokens=0,
-                    token_count_method=token_method,
-                    total_cached_tokens=0,
-                    total_cost=0.0,
-                    total_upstream_cost=0.0,
-                    total_backoff_sec=total_backoff_sec,
-                    score=0,
-                    groups_correct=0,
-                    trap_bonus=0,
-                    max_score=5 if puzzle.trap_groups is not None else 3,
-                )
-
-        # Log exchange. _parse_structured_response covers thinking/confidence;
-        # extract the <answer> block content for the 'guess' field. Strip
-        # thinking blocks first so a decoy <answer> example inside reasoning
-        # isn't logged as the guess (scoring already does the same).
-        import re
-        log_cleaned = re.sub(r'<think(?:ing)?>.*?</think(?:ing)?>', '', content, flags=re.IGNORECASE | re.DOTALL)
-        log_cleaned = re.sub(r'<think(?:ing)?>.*', '', log_cleaned, flags=re.IGNORECASE | re.DOTALL)
-        answer_match = re.search(r'<answer>(.*?)</answer>', log_cleaned, re.IGNORECASE | re.DOTALL)
-        answer_text = answer_match.group(1).strip() if answer_match else content
-        backoff_ms = int(backoff_sec * 1000)
-        inference_ms = max(0, timer.elapsed_ms - backoff_ms)
-        exchange_data = {
-            "run_id": self.run_id,
-            "model": model_name,
-            "puzzle_id": puzzle.id,
-            "guess_index": 0,
-            "request": messages[-1]["content"],
-            "response": content,
-            "thinking": structured_response.get('thinking', ''),
-            "guess": answer_text,
-            "confidence": structured_response.get('confidence', ''),
-            "latency_ms": timer.elapsed_ms,
-            "backoff_ms": backoff_ms,
-            "inference_ms": inference_ms,
-            "prompt_tokens": prompt_tokens,
-            "completion_tokens": completion_tokens,
-            "result": result,
-            "score": score,
-            "groups_correct": groups_correct,
-            "trap_bonus": trap_bonus,
-            "trap_claims": ([] if trap_claims is None
-                            else [", ".join(c) for c in trap_claims] or ["N/A"]),
-        }
-
-        if cost is not None:
-            exchange_data["cost"] = cost
-        if upstream_cost is not None:
-            exchange_data["upstream_cost"] = upstream_cost
-        if cache_info.get("cached_tokens") is not None:
-            exchange_data["cached_tokens"] = cache_info["cached_tokens"]
-        if cache_info.get("cache_discount") is not None:
-            exchange_data["cache_discount"] = cache_info["cache_discount"]
-
-        log_exchange(self.logger, exchange_data)
-
-        self._emit_model_telemetry(
-            task_id, model_id, puzzle.id, 0,
-            messages[-1]["content"], content,
-            prompt_tokens, completion_tokens, timer.elapsed_ms,
-            cost, upstream_cost, result,
-            backoff_ms=backoff_ms,
-            extra_payload={"score": score, "groups_correct": groups_correct,
-                           "trap_bonus": trap_bonus},
+        exchange = self._run_exchange(
+            ctx, puzzle, messages,
+            verdict_fn=verdict_fn,
+            guess_index_fn=lambda: 0,
+            # Mode marker: without it, a run whose every call errors has no
+            # ONESHOT_* completion strings and the MotherDuck aggregation would
+            # misclassify it as classic. MAX carries the per-puzzle score ceiling.
+            error_payload_extra={"result": f"ONESHOT_API_ERROR_MAX_{puzzle_max}"},
         )
+
+        if not exchange.ok:
+            # The error path already moved the task to FAILED. No tokens or cost
+            # are claimed for a failed call, but the puzzle still contributes its
+            # score ceiling so a partially-failed run's max_score stays honest.
+            return PuzzleResult(
+                won=False,
+                guess_count=0,
+                mistake_count=0,
+                invalid_count=0,
+                solved_groups=[],
+                time_sec=time.time() - start_time,
+                total_tokens=0,
+                total_prompt_tokens=0,
+                total_completion_tokens=0,
+                token_count_method=ctx.totals.token_method,
+                total_cached_tokens=0,
+                total_cost=0.0,
+                total_upstream_cost=0.0,
+                total_backoff_sec=ctx.totals.backoff_sec,
+                score=0,
+                groups_correct=0,
+                trap_bonus=0,
+                max_score=puzzle_max,
+            )
 
         time_sec = time.time() - start_time
 
         # Emit final state transition
-        if not final_state_emitted:
-            final_state = "DONE" if won else "FAILED"
-            try:
-                cl.state_move(
-                    task_id=task_id, from_="WIP", to=final_state,
-                    project_id="connections_eval",
-                    agent_id="agent:connections_eval",
-                    run_id=self.run_id,
-                    payload={"puzzle_id": puzzle.id},
-                )
-            except Exception:
-                pass
+        self._finish_puzzle(puzzle, ctx, won=outcome.won)
 
         return PuzzleResult(
-            won=won,
+            won=outcome.won,
             guess_count=1,
-            mistake_count=mistake_count,
-            invalid_count=invalid_count,
-            solved_groups=solved_groups,
+            mistake_count=outcome.mistake_count,
+            invalid_count=outcome.invalid_count,
+            solved_groups=outcome.solved_groups,
             time_sec=time_sec,
-            total_tokens=total_tokens,
-            total_prompt_tokens=total_prompt_tokens,
-            total_completion_tokens=total_completion_tokens,
-            token_count_method=token_method,
-            total_cached_tokens=total_cached_tokens,
-            total_cost=total_cost,
-            total_upstream_cost=total_upstream_cost,
-            total_backoff_sec=total_backoff_sec,
-            score=score,
-            groups_correct=groups_correct,
-            trap_bonus=trap_bonus,
+            **ctx.totals.as_result_fields(),
+            score=outcome.score,
+            groups_correct=outcome.groups_correct,
+            trap_bonus=outcome.trap_bonus,
             max_score=puzzle_max,
         )
 
@@ -1181,15 +1176,7 @@ class ConnectionsGame:
 
         groups_correct, score = self._score_oneshot(puzzle, groups)
         won = (groups_correct == 4)
-
-        # Structural validity mirrors _score_oneshot's gate.
-        submitted_words = [w for g in groups for w in g]
-        is_valid = (
-            len(groups) == 4
-            and all(len(g) == 4 for g in groups)
-            and len(submitted_words) == 16
-            and set(submitted_words) == set(w.upper() for w in puzzle.words)
-        )
+        is_valid = self._is_valid_oneshot_submission(puzzle, groups)
 
         # Trap claim (only when the puzzle has been reviewed for traps)
         trap_bonus = 0
@@ -1215,11 +1202,7 @@ class ConnectionsGame:
             print(f"  {group.color.upper()}: {group.name} - {', '.join(group.words)}")
 
         # Colors of matched puzzle groups (empty when invalid)
-        submitted_sets = [set(w.upper() for w in g) for g in groups]
-        solved_groups = [
-            grp.color for grp in puzzle.groups
-            if set(w.upper() for w in grp.words) in submitted_sets
-        ] if is_valid else []
+        solved_groups = self._matched_group_colors(puzzle, groups) if is_valid else []
 
         return PuzzleResult(
             won=won,

--- a/src/connections_eval/core.py
+++ b/src/connections_eval/core.py
@@ -562,9 +562,9 @@ class ConnectionsGame:
         log_summary(self.logger, summary)
         return summary
 
-    def _begin_puzzle(self, puzzle: Puzzle, model_name: str,
-                      attempt: Optional[int]) -> _PuzzleRunContext:
-        """Resolve a puzzle's transport identifiers and emit its NEW -> WIP move.
+    def _puzzle_context(self, puzzle: Puzzle, model_name: str,
+                        attempt: Optional[int]) -> _PuzzleRunContext:
+        """Resolve a puzzle's transport and telemetry identifiers.
 
         attempt: optional trial index. The normal eval path runs each puzzle once
             per run_id, so task_id is already unique. Ranking re-runs the same
@@ -574,7 +574,7 @@ class ConnectionsGame:
         """
         model_id = self.MODEL_CONFIG[model_name]
         task_id = f"T{puzzle.id}:{self.run_id}"
-        ctx = _PuzzleRunContext(
+        return _PuzzleRunContext(
             model_name=model_name,
             model_id=model_id,
             pinned_provider=openrouter_adapter.extract_provider_slug(model_id),
@@ -583,9 +583,15 @@ class ConnectionsGame:
             session_id=task_id if attempt is None else f"{task_id}:a{attempt}",
         )
 
+    def _emit_puzzle_start(self, puzzle: Puzzle, ctx: _PuzzleRunContext) -> None:
+        """Emit the NEW -> WIP transition for a puzzle.
+
+        Called only once the prompt is built and the clock is running, so a
+        failure building the prompt can't leave a task stranded in WIP.
+        """
         try:
             cl.state_move(
-                task_id=task_id, from_="NEW", to="WIP",
+                task_id=ctx.task_id, from_="NEW", to="WIP",
                 project_id="connections_eval",
                 agent_id="agent:connections_eval",
                 run_id=self.run_id,
@@ -594,9 +600,7 @@ class ConnectionsGame:
         except Exception:
             pass
 
-        return ctx
-
-    def _finish_puzzle(self, puzzle: Puzzle, ctx: _PuzzleRunContext, won: bool) -> None:
+    def _emit_puzzle_finish(self, puzzle: Puzzle, ctx: _PuzzleRunContext, won: bool) -> None:
         """Emit the final WIP -> DONE/FAILED transition for a puzzle."""
         try:
             cl.state_move(
@@ -836,9 +840,9 @@ class ConnectionsGame:
 
         Guesses one group at a time, feeding each result back to the model until
         it solves the puzzle or exhausts its mistakes/invalid responses.
-        See _begin_puzzle for the `attempt` semantics.
+        See _puzzle_context for the `attempt` semantics.
         """
-        ctx = self._begin_puzzle(puzzle, model_name, attempt)
+        ctx = self._puzzle_context(puzzle, model_name, attempt)
 
         state = GameState(
             puzzle=puzzle,
@@ -856,6 +860,7 @@ class ConnectionsGame:
         final_state_emitted = False
 
         state.start_time = time.time()
+        self._emit_puzzle_start(puzzle, ctx)
 
         while not state.finished:
             exchange = self._run_exchange(
@@ -881,7 +886,7 @@ class ConnectionsGame:
 
         # Emit final state transition
         if not final_state_emitted:
-            self._finish_puzzle(puzzle, ctx, won=state.won)
+            self._emit_puzzle_finish(puzzle, ctx, won=state.won)
 
         return PuzzleResult(
             won=state.won,
@@ -1074,14 +1079,15 @@ class ConnectionsGame:
 
         A single API call: the model submits all 4 groups at once and there is no
         feedback loop. Base score 0/1/2/3 (perfect = 3) plus a 2-point trap bonus.
-        See _begin_puzzle for the `attempt` semantics.
+        See _puzzle_context for the `attempt` semantics.
         """
-        ctx = self._begin_puzzle(puzzle, model_name, attempt)
+        ctx = self._puzzle_context(puzzle, model_name, attempt)
         messages = self._build_initial_messages(puzzle, rng)
         puzzle_max = 5 if puzzle.trap_groups is not None else 3
         outcome = _OneshotOutcome()
 
         start_time = time.time()
+        self._emit_puzzle_start(puzzle, ctx)
 
         def verdict_fn(content: str, structured: Dict[str, str]) -> _Verdict:
             nonlocal outcome
@@ -1126,7 +1132,7 @@ class ConnectionsGame:
         time_sec = time.time() - start_time
 
         # Emit final state transition
-        self._finish_puzzle(puzzle, ctx, won=outcome.won)
+        self._emit_puzzle_finish(puzzle, ctx, won=outcome.won)
 
         return PuzzleResult(
             won=outcome.won,

--- a/src/connections_eval/core.py
+++ b/src/connections_eval/core.py
@@ -987,9 +987,10 @@ class ConnectionsGame:
         """Structural validity of a one-shot submission — the single gate that
         both _score_oneshot and the ONESHOT_INVALID marker rely on.
 
-        Exactly 4 groups of 4 words whose 16 words (upper-cased) equal the
-        puzzle's words; the set comparison covers duplicates and non-puzzle
-        words at once.
+        Exactly 4 groups of 4 words whose 16 submitted words equal the puzzle's
+        words. Only puzzle.words is upper-cased here — submitted words arrive
+        already upper-cased from the parsers. The set comparison covers
+        duplicates and non-puzzle words at once.
         """
         submitted_words = [w for g in groups for w in g]
         return (

--- a/src/connections_eval/core.py
+++ b/src/connections_eval/core.py
@@ -984,10 +984,12 @@ class ConnectionsGame:
         )
 
     def _is_valid_oneshot_submission(self, puzzle: Puzzle, groups: List[List[str]]) -> bool:
-        """Structural validity of a one-shot submission.
+        """Structural validity of a one-shot submission — the single gate that
+        both _score_oneshot and the ONESHOT_INVALID marker rely on.
 
-        Mirrors _score_oneshot's gate: exactly 4 groups of 4 words that together
-        equal the puzzle's 16 words.
+        Exactly 4 groups of 4 words whose 16 words (upper-cased) equal the
+        puzzle's words; the set comparison covers duplicates and non-puzzle
+        words at once.
         """
         submitted_words = [w for g in groups for w in g]
         return (
@@ -1013,9 +1015,9 @@ class ConnectionsGame:
         string and the score fields attached to the log and telemetry.
         """
         groups = self._parse_oneshot_response(content)
+        is_valid = self._is_valid_oneshot_submission(puzzle, groups)
         groups_correct, score = self._score_oneshot(puzzle, groups)
         won = (groups_correct == 4)
-        is_valid = self._is_valid_oneshot_submission(puzzle, groups)
 
         if not is_valid:
             # A structurally invalid answer scores 0 overall — the trap
@@ -1393,22 +1395,13 @@ class ConnectionsGame:
         Score a one-shot submission.
 
         Returns:
-            (groups_correct, base_score). Any structural failure returns (0, 0):
-            not exactly 4 groups, not exactly 4 words per group, or the 16 words
-            (upper-cased) not exactly equal to the puzzle's words. Otherwise
-            base_score = matches for 0/1/2, and 3 for a perfect solve (exactly
-            3 matches is impossible — the 4th group is forced). Trap bonus is
-            scored separately by _score_trap_claims.
+            (groups_correct, base_score). A structurally invalid submission (see
+            _is_valid_oneshot_submission) returns (0, 0). Otherwise base_score =
+            matches for 0/1/2, and 3 for a perfect solve (exactly 3 matches is
+            impossible — the 4th group is forced). Trap bonus is scored
+            separately by _score_trap_claims.
         """
-        # Structural validation: exactly 4 groups of 4 words
-        if len(groups) != 4 or any(len(group) != 4 for group in groups):
-            return (0, 0)
-
-        # The 16 submitted words must exactly equal the puzzle's words (covers
-        # duplicates and non-puzzle words in a single set comparison).
-        submitted_words = [word for group in groups for word in group]
-        puzzle_words = set(word.upper() for word in puzzle.words)
-        if len(submitted_words) != 16 or set(submitted_words) != puzzle_words:
+        if not self._is_valid_oneshot_submission(puzzle, groups):
             return (0, 0)
 
         # Count submitted groups whose word-set matches some puzzle group's word-set

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,10 +3,12 @@
 import random
 import pytest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from connections_eval import core as core_mod
 from connections_eval.core import ConnectionsGame, GameState, Puzzle, PuzzleGroup, PuzzleResult, EvalStats
+from connections_eval.adapters import openrouter_adapter
 from connections_eval.adapters.openrouter_adapter import extract_provider_slug
 from connections_eval.utils.tokens import extract_cache_info
 
@@ -1417,9 +1419,15 @@ class TestAdapterChoicesFix:
 
 class TestSharedExchangeScaffolding:
     """Both runners share _run_exchange for transport, accounting and telemetry.
-    These lock in the mode-specific pieces that must stay distinct."""
+    These lock in the compatibility contract that MotherDuck aggregation
+    (scripts/extract_summaries.py, scripts/generate_logs_view.py) parses, plus the
+    mode-specific pieces that must stay distinct."""
 
     _INPUTS = Path(__file__).resolve().parent.parent / "inputs"
+    # One annotated trap set: one word from each real group, so it satisfies the
+    # cross-cutting rule in _score_trap_claims.
+    _TRAP = ["APPLE", "BLUE", "FAST", "BRIGHT"]
+    _TRAP_GROUPS = [_TRAP]
 
     def _make_game(self, tmp_path, puzzle, mode):
         with patch.object(ConnectionsGame, '_load_puzzles', return_value=[puzzle]), \
@@ -1436,72 +1444,122 @@ class TestSharedExchangeScaffolding:
         return p
 
     @staticmethod
-    def _response(content):
+    def _response(content, cost=None, cached=None):
+        usage = {"prompt_tokens": 100, "completion_tokens": 50}
+        if cost is not None:
+            usage["cost"] = cost
+            # upstream_inference_cost is only additive (and only recorded) for BYOK
+            usage["cost_details"] = {"upstream_inference_cost": cost * 2}
+            usage["is_byok"] = True
+        if cached is not None:
+            usage["prompt_tokens_details"] = {"cached_tokens": cached}
         return {
             "choices": [{"message": {"content": content}, "finish_reason": "stop"}],
-            "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+            "usage": usage,
         }
 
-    def _run(self, tmp_path, mode, side_effect):
-        """Run one puzzle, returning (summary, exchange_logs, controllog_events)."""
-        puzzle = self._puzzle(trap_groups=[["APPLE", "BLUE", "FAST", "BRIGHT"]])
-        game = self._make_game(tmp_path, puzzle, mode)
+    @staticmethod
+    def _answer(traps=None):
+        answer = "<answer>\n" + "\n".join(
+            ", ".join(g.words) for g in _make_test_groups()) + "\n</answer>"
+        return answer if traps is None else f"{answer}\n<traps>\n{traps}\n</traps>"
 
-        exchanges, events = [], []
+    @staticmethod
+    def _guesses(**response_kwargs):
+        return [TestSharedExchangeScaffolding._response(
+            f"<guess>{', '.join(g.words)}</guess>", **response_kwargs)
+            for g in _make_test_groups()]
+
+    def _run(self, tmp_path, mode, side_effect, trap_groups=None, game=None):
+        """Run one puzzle, capturing every logged/emitted side effect."""
+        puzzle = self._puzzle(trap_groups=trap_groups or self._TRAP_GROUPS)
+        game = game or self._make_game(tmp_path, puzzle, mode)
+
+        cap = SimpleNamespace(exchanges=[], events=[], moves=[], prompts=[],
+                              completions=[], summary=None, chat=None)
         with patch("connections_eval.core.openrouter_adapter.chat",
                    side_effect=side_effect) as chat_mock, \
              patch("connections_eval.core.log_exchange",
-                   side_effect=lambda logger, data: exchanges.append(data)), \
+                   side_effect=lambda logger, data: cap.exchanges.append(data)), \
              patch.object(core_mod.cl, "event",
-                          side_effect=lambda **kw: events.append(kw)):
-            summary = game.run_evaluation("test-model", puzzle_ids=[477])
-        return summary, exchanges, events, chat_mock
+                          side_effect=lambda **kw: cap.events.append(kw)), \
+             patch.object(core_mod.cl, "state_move",
+                          side_effect=lambda **kw: cap.moves.append(kw)), \
+             patch.object(core_mod.cl, "model_prompt",
+                          side_effect=lambda **kw: cap.prompts.append(kw)), \
+             patch.object(core_mod.cl, "model_completion",
+                          side_effect=lambda **kw: cap.completions.append(kw)):
+            cap.summary = game.run_evaluation("test-model", puzzle_ids=[477])
+        cap.chat = chat_mock
+        return cap
+
+    # --- shared plumbing -------------------------------------------------
 
     def test_reasoning_effort_reaches_adapter_in_both_modes(self, tmp_path):
-        answer = "<answer>\n" + "\n".join(
-            ", ".join(g.words) for g in _make_test_groups()) + "\n</answer>"
-        for mode, content in (("oneshot", answer),
+        for mode, content in (("oneshot", self._answer()),
                               ("classic", "<guess>APPLE, BANANA, CHERRY, GRAPE</guess>")):
-            _, _, _, chat_mock = self._run(
-                tmp_path, mode, [self._response(content)] * 6)
-            assert chat_mock.call_args.kwargs["reasoning_effort"] == "high"
+            cap = self._run(tmp_path, mode, [self._response(content)] * 6)
+            assert cap.chat.call_args.kwargs["reasoning_effort"] == "high"
 
-    def test_classic_api_error_event_has_no_oneshot_marker(self, tmp_path):
-        """The ONESHOT_API_ERROR_MAX_n mode marker must not leak into classic
-        runs — MotherDuck uses it to classify a fully-failed run's mode."""
-        _, exchanges, events, _ = self._run(tmp_path, "classic", RuntimeError("boom"))
+    def test_totals_accumulate_across_classic_turns(self, tmp_path):
+        """Four turns of 100/50 tokens, $0.01 and 40 cached tokens each."""
+        cap = self._run(tmp_path, "classic", self._guesses(cost=0.01, cached=40))
 
-        assert [e["result"] for e in exchanges] == ["API_ERROR"]
-        errors = [e for e in events if e["kind"] == "model_response_error"]
-        assert len(errors) == 1
-        assert "result" not in errors[0]["payload"]
+        assert cap.summary["total_prompt_tokens"] == 400
+        assert cap.summary["total_completion_tokens"] == 200
+        assert cap.summary["total_tokens"] == 600
+        assert cap.summary["total_cached_tokens"] == 160
+        assert cap.summary["total_cost"] == pytest.approx(0.04)
+        assert cap.summary["total_upstream_cost"] == pytest.approx(0.08)
+        assert cap.summary["token_count_method"] == "API"
 
-    def test_oneshot_api_error_event_carries_max_marker(self, tmp_path):
-        _, exchanges, events, _ = self._run(tmp_path, "oneshot", RuntimeError("boom"))
+    def test_oneshot_totals_come_from_single_call(self, tmp_path):
+        cap = self._run(tmp_path, "oneshot",
+                        [self._response(self._answer(), cost=0.01, cached=40)])
 
-        assert [e["result"] for e in exchanges] == ["API_ERROR"]
-        errors = [e for e in events if e["kind"] == "model_response_error"]
-        assert errors[0]["payload"]["result"] == "ONESHOT_API_ERROR_MAX_5"
+        assert cap.summary["total_prompt_tokens"] == 100
+        assert cap.summary["total_completion_tokens"] == 50
+        assert cap.summary["total_cached_tokens"] == 40
+        assert cap.summary["total_cost"] == pytest.approx(0.01)
+        assert cap.summary["total_upstream_cost"] == pytest.approx(0.02)
+
+    # --- exchange log shape (parsed by generate_logs_view) ---------------
+
+    _BASE_LOG_FIELDS = [
+        "run_id", "model", "puzzle_id", "guess_index", "request", "response",
+        "thinking", "guess", "confidence", "latency_ms", "backoff_ms",
+        "inference_ms", "prompt_tokens", "completion_tokens", "result",
+    ]
+
+    def test_classic_exchange_log_field_order(self, tmp_path):
+        cap = self._run(tmp_path, "classic", self._guesses(cost=0.01, cached=40))
+
+        assert list(cap.exchanges[0].keys()) == self._BASE_LOG_FIELDS + [
+            "cost", "upstream_cost", "cached_tokens"]
+        # Classic exchanges carry no one-shot score fields
+        assert all("score" not in e for e in cap.exchanges)
+
+    def test_oneshot_exchange_log_field_order(self, tmp_path):
+        cap = self._run(tmp_path, "oneshot",
+                        [self._response(self._answer(), cost=0.01, cached=40)])
+
+        assert list(cap.exchanges[0].keys()) == self._BASE_LOG_FIELDS + [
+            "score", "groups_correct", "trap_bonus", "trap_claims",
+            "cost", "upstream_cost", "cached_tokens"]
 
     def test_classic_exchange_log_records_post_guess_index(self, tmp_path):
         """Classic logs the guess index *after* the guess is counted, so a run of
         correct guesses logs 1..4 rather than 0..3."""
-        guesses = [self._response(f"<guess>{', '.join(g.words)}</guess>")
-                   for g in _make_test_groups()]
-        _, exchanges, _, _ = self._run(tmp_path, "classic", guesses)
+        cap = self._run(tmp_path, "classic", self._guesses())
 
-        assert [e["guess_index"] for e in exchanges] == [1, 2, 3, 4]
-        # Classic exchanges carry no one-shot score fields
-        assert all("score" not in e for e in exchanges)
+        assert [e["guess_index"] for e in cap.exchanges] == [1, 2, 3, 4]
+        assert [c["payload"]["guess_index"] for c in cap.completions] == [1, 2, 3, 4]
 
     def test_oneshot_exchange_log_carries_score_fields(self, tmp_path):
-        answer = "<answer>\n" + "\n".join(
-            ", ".join(g.words) for g in _make_test_groups()
-        ) + "\n</answer>\n<traps>\nAPPLE, BLUE, FAST, BRIGHT\n</traps>"
-        _, exchanges, _, _ = self._run(tmp_path, "oneshot", [self._response(answer)])
+        cap = self._run(tmp_path, "oneshot",
+                        [self._response(self._answer(traps=", ".join(self._TRAP)))])
 
-        assert len(exchanges) == 1
-        logged = exchanges[0]
+        logged = cap.exchanges[0]
         assert logged["guess_index"] == 0
         assert logged["result"] == "ONESHOT_SCORE_5_GROUPS_4_TRAP_2_MAX_5"
         assert logged["score"] == 5
@@ -1511,10 +1569,95 @@ class TestSharedExchangeScaffolding:
         # 'guess' is the <answer> block, not the classic <guess> tag
         assert "APPLE, BANANA, CHERRY, GRAPE" in logged["guess"]
 
-    def test_non_retryable_error_still_aborts_both_modes(self, tmp_path):
-        class NoCredits(RuntimeError):
-            non_retryable = True
+    # --- controllog telemetry (parsed by extract_summaries) --------------
 
+    def test_classic_telemetry_payloads(self, tmp_path):
+        cap = self._run(tmp_path, "classic", self._guesses())
+
+        assert [p["payload"] for p in cap.prompts] == [
+            {"puzzle_id": 477, "guess_index": i} for i in (1, 2, 3, 4)]
+        # Verdict strings feed the classic solve/mistake aggregation
+        assert [c["payload"] for c in cap.completions] == [
+            {"puzzle_id": 477, "guess_index": 1, "result": "CORRECT. NEXT GUESS?"},
+            {"puzzle_id": 477, "guess_index": 2, "result": "CORRECT. NEXT GUESS?"},
+            {"puzzle_id": 477, "guess_index": 3, "result": "CORRECT. NEXT GUESS?"},
+            {"puzzle_id": 477, "guess_index": 4, "result": "CORRECT"},
+        ]
+
+    def test_oneshot_telemetry_payload_carries_score_fields(self, tmp_path):
+        cap = self._run(tmp_path, "oneshot",
+                        [self._response(self._answer(traps=", ".join(self._TRAP)))])
+
+        assert cap.prompts[0]["payload"] == {"puzzle_id": 477, "guess_index": 0}
+        assert cap.completions[0]["payload"] == {
+            "puzzle_id": 477, "guess_index": 0,
+            "result": "ONESHOT_SCORE_5_GROUPS_4_TRAP_2_MAX_5",
+            "score": 5, "groups_correct": 4, "trap_bonus": 2,
+        }
+
+    # --- state transitions ----------------------------------------------
+
+    @staticmethod
+    def _transitions(cap):
+        return [(m["from_"], m["to"]) for m in cap.moves]
+
+    def test_solved_puzzle_moves_new_wip_done(self, tmp_path):
+        for mode, side_effect in (("classic", self._guesses()),
+                                  ("oneshot", [self._response(self._answer())])):
+            cap = self._run(tmp_path, mode, side_effect)
+            assert self._transitions(cap) == [("NEW", "WIP"), ("WIP", "DONE")]
+
+    def test_api_error_moves_wip_failed_exactly_once(self, tmp_path):
         for mode in ("classic", "oneshot"):
-            with pytest.raises(NoCredits):
-                self._run(tmp_path, mode, NoCredits("insufficient credits"))
+            cap = self._run(tmp_path, mode, RuntimeError("boom"))
+            assert self._transitions(cap) == [("NEW", "WIP"), ("WIP", "FAILED")]
+            assert cap.moves[-1]["payload"] == {"puzzle_id": 477, "reason": "api_error"}
+
+    def test_prompt_build_failure_leaves_no_wip_task(self, tmp_path):
+        """WIP is only claimed once the prompt exists, so a prompt-build failure
+        can't strand a task in WIP with no terminal transition."""
+        for mode in ("classic", "oneshot"):
+            game = self._make_game(tmp_path, self._puzzle(self._TRAP_GROUPS), mode)
+            with patch.object(game, "_build_initial_messages",
+                              side_effect=RuntimeError("bad template")):
+                cap = self._run(tmp_path, mode, [self._response("")], game=game)
+            assert cap.moves == []
+            assert cap.summary["puzzles_attempted"] == 0
+
+    # --- error paths -----------------------------------------------------
+
+    def test_classic_api_error_event_has_no_oneshot_marker(self, tmp_path):
+        """The ONESHOT_API_ERROR_MAX_n mode marker must not leak into classic
+        runs — MotherDuck uses it to classify a fully-failed run's mode."""
+        cap = self._run(tmp_path, "classic", RuntimeError("boom"))
+
+        assert [e["result"] for e in cap.exchanges] == ["API_ERROR"]
+        errors = [e for e in cap.events if e["kind"] == "model_response_error"]
+        assert len(errors) == 1
+        assert "result" not in errors[0]["payload"]
+
+    def test_oneshot_api_error_event_carries_max_marker(self, tmp_path):
+        cap = self._run(tmp_path, "oneshot", RuntimeError("boom"))
+
+        assert [e["result"] for e in cap.exchanges] == ["API_ERROR"]
+        errors = [e for e in cap.events if e["kind"] == "model_response_error"]
+        assert errors[0]["payload"]["result"] == "ONESHOT_API_ERROR_MAX_5"
+        # A failed call claims no tokens or cost, but still contributes the ceiling
+        assert cap.summary["total_tokens"] == 0
+        assert cap.summary["total_cost"] == 0.0
+        assert cap.summary["max_score"] == 5
+
+    def test_insufficient_credits_aborts_both_modes(self, tmp_path):
+        """402 must abort the run with no summary, in both modes."""
+        for mode in ("classic", "oneshot"):
+            with pytest.raises(openrouter_adapter.InsufficientCreditsError):
+                self._run(tmp_path, mode,
+                          openrouter_adapter.InsufficientCreditsError("no credits"))
+
+    def test_insufficient_credits_aborts_parallel_run(self, tmp_path):
+        puzzle = self._puzzle(self._TRAP_GROUPS)
+        game = self._make_game(tmp_path, puzzle, "oneshot")
+        with patch("connections_eval.core.openrouter_adapter.chat",
+                   side_effect=openrouter_adapter.InsufficientCreditsError("no credits")), \
+             pytest.raises(openrouter_adapter.InsufficientCreditsError):
+            game.run_evaluation("test-model", puzzle_ids=[477], threads=4)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -719,8 +719,15 @@ class TestOneshotTraps:
         # Any 4-subset of the 5-word superset that isn't the real group scores
         assert mock_game._score_trap_claims(trap_puzzle, [["RED", "YELLOW", "APPLE", "WISE"]]) == 2
 
-    def test_real_group_subset_of_superset_rejected(self, mock_game, trap_puzzle):
-        # The real Smart group is inside the superset but is NOT a trap
+    def test_exact_real_group_claim_rejected(self, mock_game, trap_puzzle):
+        """A real group is never a trap, even when it shares a word with an
+        annotation (WISE is in the superset). Rejected twice over: it is a real
+        group, and it takes 4 words from one group.
+
+        Note a real group can never be *inside* an annotated superset — that
+        would need 3+ words from one group, which the scorer's <=2 rule bars
+        (see test_three_from_one_group_never_scores_even_if_annotated).
+        """
         assert mock_game._score_trap_claims(trap_puzzle, [["BRIGHT", "CLEVER", "SMART", "WISE"]]) == 0
 
     def test_only_first_claim_judged_bogus_second_ignored(self, mock_game, trap_puzzle):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from connections_eval import core as core_mod
 from connections_eval.core import ConnectionsGame, GameState, Puzzle, PuzzleGroup, PuzzleResult, EvalStats
 from connections_eval.adapters.openrouter_adapter import extract_provider_slug
 from connections_eval.utils.tokens import extract_cache_info
@@ -1412,3 +1413,108 @@ class TestAdapterChoicesFix:
         result = chat([{"role": "user", "content": "test"}], "openai/o3", provider=None)
 
         assert result["_backoff_sec"] == 0.0
+
+
+class TestSharedExchangeScaffolding:
+    """Both runners share _run_exchange for transport, accounting and telemetry.
+    These lock in the mode-specific pieces that must stay distinct."""
+
+    _INPUTS = Path(__file__).resolve().parent.parent / "inputs"
+
+    def _make_game(self, tmp_path, puzzle, mode):
+        with patch.object(ConnectionsGame, '_load_puzzles', return_value=[puzzle]), \
+             patch.object(ConnectionsGame, '_load_model_mappings',
+                          return_value={"test-model": "openai/o3"}):
+            return ConnectionsGame(self._INPUTS, tmp_path, seed=42, mode=mode,
+                                   reasoning_effort="high")
+
+    @staticmethod
+    def _puzzle(trap_groups=None):
+        p = Puzzle(id=477, date="2024-09-30", difficulty=3.8,
+                   words=list(_TEST_WORDS), groups=_make_test_groups())
+        p.trap_groups = trap_groups
+        return p
+
+    @staticmethod
+    def _response(content):
+        return {
+            "choices": [{"message": {"content": content}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+        }
+
+    def _run(self, tmp_path, mode, side_effect):
+        """Run one puzzle, returning (summary, exchange_logs, controllog_events)."""
+        puzzle = self._puzzle(trap_groups=[["APPLE", "BLUE", "FAST", "BRIGHT"]])
+        game = self._make_game(tmp_path, puzzle, mode)
+
+        exchanges, events = [], []
+        with patch("connections_eval.core.openrouter_adapter.chat",
+                   side_effect=side_effect) as chat_mock, \
+             patch("connections_eval.core.log_exchange",
+                   side_effect=lambda logger, data: exchanges.append(data)), \
+             patch.object(core_mod.cl, "event",
+                          side_effect=lambda **kw: events.append(kw)):
+            summary = game.run_evaluation("test-model", puzzle_ids=[477])
+        return summary, exchanges, events, chat_mock
+
+    def test_reasoning_effort_reaches_adapter_in_both_modes(self, tmp_path):
+        answer = "<answer>\n" + "\n".join(
+            ", ".join(g.words) for g in _make_test_groups()) + "\n</answer>"
+        for mode, content in (("oneshot", answer),
+                              ("classic", "<guess>APPLE, BANANA, CHERRY, GRAPE</guess>")):
+            _, _, _, chat_mock = self._run(
+                tmp_path, mode, [self._response(content)] * 6)
+            assert chat_mock.call_args.kwargs["reasoning_effort"] == "high"
+
+    def test_classic_api_error_event_has_no_oneshot_marker(self, tmp_path):
+        """The ONESHOT_API_ERROR_MAX_n mode marker must not leak into classic
+        runs — MotherDuck uses it to classify a fully-failed run's mode."""
+        _, exchanges, events, _ = self._run(tmp_path, "classic", RuntimeError("boom"))
+
+        assert [e["result"] for e in exchanges] == ["API_ERROR"]
+        errors = [e for e in events if e["kind"] == "model_response_error"]
+        assert len(errors) == 1
+        assert "result" not in errors[0]["payload"]
+
+    def test_oneshot_api_error_event_carries_max_marker(self, tmp_path):
+        _, exchanges, events, _ = self._run(tmp_path, "oneshot", RuntimeError("boom"))
+
+        assert [e["result"] for e in exchanges] == ["API_ERROR"]
+        errors = [e for e in events if e["kind"] == "model_response_error"]
+        assert errors[0]["payload"]["result"] == "ONESHOT_API_ERROR_MAX_5"
+
+    def test_classic_exchange_log_records_post_guess_index(self, tmp_path):
+        """Classic logs the guess index *after* the guess is counted, so a run of
+        correct guesses logs 1..4 rather than 0..3."""
+        guesses = [self._response(f"<guess>{', '.join(g.words)}</guess>")
+                   for g in _make_test_groups()]
+        _, exchanges, _, _ = self._run(tmp_path, "classic", guesses)
+
+        assert [e["guess_index"] for e in exchanges] == [1, 2, 3, 4]
+        # Classic exchanges carry no one-shot score fields
+        assert all("score" not in e for e in exchanges)
+
+    def test_oneshot_exchange_log_carries_score_fields(self, tmp_path):
+        answer = "<answer>\n" + "\n".join(
+            ", ".join(g.words) for g in _make_test_groups()
+        ) + "\n</answer>\n<traps>\nAPPLE, BLUE, FAST, BRIGHT\n</traps>"
+        _, exchanges, _, _ = self._run(tmp_path, "oneshot", [self._response(answer)])
+
+        assert len(exchanges) == 1
+        logged = exchanges[0]
+        assert logged["guess_index"] == 0
+        assert logged["result"] == "ONESHOT_SCORE_5_GROUPS_4_TRAP_2_MAX_5"
+        assert logged["score"] == 5
+        assert logged["groups_correct"] == 4
+        assert logged["trap_bonus"] == 2
+        assert logged["trap_claims"] == ["APPLE, BLUE, FAST, BRIGHT"]
+        # 'guess' is the <answer> block, not the classic <guess> tag
+        assert "APPLE, BANANA, CHERRY, GRAPE" in logged["guess"]
+
+    def test_non_retryable_error_still_aborts_both_modes(self, tmp_path):
+        class NoCredits(RuntimeError):
+            non_retryable = True
+
+        for mode in ("classic", "oneshot"):
+            with pytest.raises(NoCredits):
+                self._run(tmp_path, mode, NoCredits("insufficient credits"))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 """Tests for core game logic."""
 
 import random
+import time
 import pytest
 from pathlib import Path
 from types import SimpleNamespace
@@ -1707,21 +1708,31 @@ class TestSharedExchangeScaffolding:
     def test_backoff_is_split_out_of_inference_time(self, tmp_path):
         """Retry sleep is attributed as backoff, kept out of inference_ms, and
         posted as its own model_backoff event."""
+        # Each call burns 60ms of wall time and reports 10ms of it as backoff, so
+        # inference_ms lands strictly between 0 and latency_ms — the subtraction
+        # is only observable when latency exceeds the backoff.
         responses = self._guesses()
         for r in responses:
-            r["_backoff_sec"] = 1.5
-        cap = self._run(tmp_path, "classic", responses)
+            r["_backoff_sec"] = 0.01
 
-        assert cap.summary["total_backoff_sec"] == pytest.approx(6.0)
-        # Wall time here is ~0, so inference clamps to 0 rather than going negative
-        assert all(e["backoff_ms"] == 1500 for e in cap.exchanges)
-        assert all(e["inference_ms"] == max(0, e["latency_ms"] - 1500)
-                   for e in cap.exchanges)
-        assert cap.summary["total_inference_sec"] == 0.0
+        def slow_chat(*args, **kwargs):
+            time.sleep(0.06)
+            return responses.pop(0)
+
+        cap = self._run(tmp_path, "classic", slow_chat)
+
+        assert cap.summary["total_backoff_sec"] == pytest.approx(0.04)
+        assert all(e["backoff_ms"] == 10 for e in cap.exchanges)
+        assert all(e["latency_ms"] >= 50 for e in cap.exchanges)
+        assert all(e["inference_ms"] == e["latency_ms"] - 10 for e in cap.exchanges)
+        assert all(0 < e["inference_ms"] < e["latency_ms"] for e in cap.exchanges)
+        # Run-level inference time is wall time minus the backoff share
+        assert cap.summary["total_inference_sec"] == pytest.approx(
+            cap.summary["total_time_sec"] - 0.04, abs=1e-3)
 
         backoffs = [e for e in cap.events if e["kind"] == "model_backoff"]
         assert len(backoffs) == 4
-        assert backoffs[0]["payload"]["backoff_ms"] == 1500
+        assert backoffs[0]["payload"]["backoff_ms"] == 10
 
     def test_error_path_attributes_last_backoff(self, tmp_path):
         """Backoff burned before a call finally failed is still accounted for."""
@@ -1735,25 +1746,55 @@ class TestSharedExchangeScaffolding:
     def test_parallel_puzzles_get_isolated_contexts_and_summed_totals(self, tmp_path):
         """Two puzzles across two threads: each gets its own task/session id and
         its own accounting, and the run totals are the sum."""
+        # Puzzle 246 swaps GRAPE -> MELON so the two prompts are distinguishable
+        # and each thread's request can be tied back to its own puzzle.
         puzzles = [self._puzzle(self._TRAP_GROUPS), self._puzzle(self._TRAP_GROUPS)]
         puzzles[1].id = 246
+        puzzles[1].words = ["MELON" if w == "GRAPE" else w for w in puzzles[1].words]
+        puzzles[1].groups = _make_test_groups()
+        puzzles[1].groups[0].words = ["APPLE", "BANANA", "CHERRY", "MELON"]
+        answers = {
+            477: self._answer(),
+            246: "<answer>\n" + "\n".join(
+                ", ".join(g.words) for g in puzzles[1].groups) + "\n</answer>",
+        }
         with patch.object(ConnectionsGame, '_load_puzzles', return_value=puzzles), \
              patch.object(ConnectionsGame, '_load_model_mappings',
                           return_value={"test-model": "openai/o3"}):
             game = ConnectionsGame(self._INPUTS, tmp_path, seed=42, mode="oneshot")
 
-        prompts, sessions = [], []
+        # Correlating each request's session_id with the puzzle its prompt is for
+        # catches a context swap between threads — which asserting on id sets
+        # alone would not.
+        sessions = {}
+
+        def capture_chat(messages, model_id, provider=None, session_id=None, **kwargs):
+            rendered = " ".join(m["content"] for m in messages)
+            pid = 246 if "MELON" in rendered else 477
+            sessions[pid] = session_id
+            return self._response(answers[pid])
+
+        prompts, completions, exchanges = [], [], []
         with patch("connections_eval.core.openrouter_adapter.chat",
-                   side_effect=lambda *a, **kw: (sessions.append(kw["session_id"]),
-                                                 self._response(self._answer()))[1]), \
+                   side_effect=capture_chat), \
+             patch("connections_eval.core.log_exchange",
+                   side_effect=lambda logger, data: exchanges.append(data)), \
              patch.object(core_mod.cl, "model_prompt",
-                          side_effect=lambda **kw: prompts.append(kw)):
+                          side_effect=lambda **kw: prompts.append(kw)), \
+             patch.object(core_mod.cl, "model_completion",
+                          side_effect=lambda **kw: completions.append(kw)):
             summary = game.run_evaluation("test-model", puzzle_ids=[477, 246], threads=2)
 
         assert summary["puzzles_attempted"] == 2
         assert summary["puzzles_solved"] == 2
         assert summary["total_prompt_tokens"] == 200
         assert summary["total_completion_tokens"] == 100
-        assert sorted(sessions) == sorted(f"T{pid}:{game.run_id}" for pid in (477, 246))
-        assert sorted(p["task_id"] for p in prompts) == sorted(sessions)
-        assert sorted(p["payload"]["puzzle_id"] for p in prompts) == [246, 477]
+
+        # Each puzzle's sticky-routing session and telemetry task id are its own
+        expected = {pid: f"T{pid}:{game.run_id}" for pid in (477, 246)}
+        assert sessions == expected
+        assert {p["payload"]["puzzle_id"]: p["task_id"] for p in prompts} == expected
+        assert {c["payload"]["puzzle_id"]: c["task_id"] for c in completions} == expected
+        assert {e["puzzle_id"] for e in exchanges} == {477, 246}
+        # Per-puzzle accounting stayed separate rather than doubling up
+        assert all(e["prompt_tokens"] == 100 for e in exchanges)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1428,6 +1428,9 @@ class TestSharedExchangeScaffolding:
     # cross-cutting rule in _score_trap_claims.
     _TRAP = ["APPLE", "BLUE", "FAST", "BRIGHT"]
     _TRAP_GROUPS = [_TRAP]
+    # Distinguishes "caller didn't say" from trap_groups=None (unreviewed puzzle)
+    # and trap_groups=[] (reviewed, trap-free), which score differently.
+    _DEFAULT_TRAPS = object()
 
     def _make_game(self, tmp_path, puzzle, mode):
         with patch.object(ConnectionsGame, '_load_puzzles', return_value=[puzzle]), \
@@ -1470,9 +1473,11 @@ class TestSharedExchangeScaffolding:
             f"<guess>{', '.join(g.words)}</guess>", **response_kwargs)
             for g in _make_test_groups()]
 
-    def _run(self, tmp_path, mode, side_effect, trap_groups=None, game=None):
+    def _run(self, tmp_path, mode, side_effect, trap_groups=_DEFAULT_TRAPS, game=None):
         """Run one puzzle, capturing every logged/emitted side effect."""
-        puzzle = self._puzzle(trap_groups=trap_groups or self._TRAP_GROUPS)
+        if trap_groups is self._DEFAULT_TRAPS:
+            trap_groups = self._TRAP_GROUPS
+        puzzle = self._puzzle(trap_groups=trap_groups)
         game = game or self._make_game(tmp_path, puzzle, mode)
 
         cap = SimpleNamespace(exchanges=[], events=[], moves=[], prompts=[],
@@ -1661,3 +1666,94 @@ class TestSharedExchangeScaffolding:
                    side_effect=openrouter_adapter.InsufficientCreditsError("no credits")), \
              pytest.raises(openrouter_adapter.InsufficientCreditsError):
             game.run_evaluation("test-model", puzzle_ids=[477], threads=4)
+
+    # --- per-puzzle MAX ceiling (parsed out of the result strings) --------
+
+    def test_unreviewed_puzzle_caps_at_max_3(self, tmp_path):
+        """trap_groups=None means traps were never reviewed: no bonus is possible
+        even for a correct-looking claim, and every marker carries MAX_3."""
+        cap = self._run(tmp_path, "oneshot",
+                        [self._response(self._answer(traps=", ".join(self._TRAP)))],
+                        trap_groups=None)
+
+        assert cap.exchanges[0]["result"] == "ONESHOT_SCORE_3_GROUPS_4_TRAP_0_MAX_3"
+        assert cap.exchanges[0]["trap_bonus"] == 0
+        assert cap.summary["total_score"] == 3
+        assert cap.summary["max_score"] == 3
+
+    def test_reviewed_trapless_puzzle_scores_na_claim(self, tmp_path):
+        """trap_groups=[] means reviewed and trap-free, so N/A earns the +2."""
+        cap = self._run(tmp_path, "oneshot",
+                        [self._response(self._answer(traps="N/A"))], trap_groups=[])
+
+        assert cap.exchanges[0]["result"] == "ONESHOT_SCORE_5_GROUPS_4_TRAP_2_MAX_5"
+        assert cap.exchanges[0]["trap_claims"] == ["N/A"]
+        assert cap.summary["max_score"] == 5
+
+    def test_invalid_and_error_markers_carry_unreviewed_ceiling(self, tmp_path):
+        invalid = self._run(tmp_path, "oneshot", [self._response("no answer here")],
+                            trap_groups=None)
+        assert invalid.exchanges[0]["result"] == "ONESHOT_INVALID_MAX_3"
+        assert invalid.exchanges[0]["trap_claims"] == []
+        assert invalid.summary["invalid_responses"] == 1
+
+        errored = self._run(tmp_path, "oneshot", RuntimeError("boom"), trap_groups=None)
+        errors = [e for e in errored.events if e["kind"] == "model_response_error"]
+        assert errors[0]["payload"]["result"] == "ONESHOT_API_ERROR_MAX_3"
+        assert errored.summary["max_score"] == 3
+
+    # --- backoff accounting ----------------------------------------------
+
+    def test_backoff_is_split_out_of_inference_time(self, tmp_path):
+        """Retry sleep is attributed as backoff, kept out of inference_ms, and
+        posted as its own model_backoff event."""
+        responses = self._guesses()
+        for r in responses:
+            r["_backoff_sec"] = 1.5
+        cap = self._run(tmp_path, "classic", responses)
+
+        assert cap.summary["total_backoff_sec"] == pytest.approx(6.0)
+        # Wall time here is ~0, so inference clamps to 0 rather than going negative
+        assert all(e["backoff_ms"] == 1500 for e in cap.exchanges)
+        assert all(e["inference_ms"] == max(0, e["latency_ms"] - 1500)
+                   for e in cap.exchanges)
+        assert cap.summary["total_inference_sec"] == 0.0
+
+        backoffs = [e for e in cap.events if e["kind"] == "model_backoff"]
+        assert len(backoffs) == 4
+        assert backoffs[0]["payload"]["backoff_ms"] == 1500
+
+    def test_error_path_attributes_last_backoff(self, tmp_path):
+        """Backoff burned before a call finally failed is still accounted for."""
+        for mode in ("classic", "oneshot"):
+            with patch.object(core_mod, "get_last_backoff_sec", return_value=2.0):
+                cap = self._run(tmp_path, mode, RuntimeError("boom"))
+            assert cap.summary["total_backoff_sec"] == pytest.approx(2.0)
+
+    # --- thread isolation -------------------------------------------------
+
+    def test_parallel_puzzles_get_isolated_contexts_and_summed_totals(self, tmp_path):
+        """Two puzzles across two threads: each gets its own task/session id and
+        its own accounting, and the run totals are the sum."""
+        puzzles = [self._puzzle(self._TRAP_GROUPS), self._puzzle(self._TRAP_GROUPS)]
+        puzzles[1].id = 246
+        with patch.object(ConnectionsGame, '_load_puzzles', return_value=puzzles), \
+             patch.object(ConnectionsGame, '_load_model_mappings',
+                          return_value={"test-model": "openai/o3"}):
+            game = ConnectionsGame(self._INPUTS, tmp_path, seed=42, mode="oneshot")
+
+        prompts, sessions = [], []
+        with patch("connections_eval.core.openrouter_adapter.chat",
+                   side_effect=lambda *a, **kw: (sessions.append(kw["session_id"]),
+                                                 self._response(self._answer()))[1]), \
+             patch.object(core_mod.cl, "model_prompt",
+                          side_effect=lambda **kw: prompts.append(kw)):
+            summary = game.run_evaluation("test-model", puzzle_ids=[477, 246], threads=2)
+
+        assert summary["puzzles_attempted"] == 2
+        assert summary["puzzles_solved"] == 2
+        assert summary["total_prompt_tokens"] == 200
+        assert summary["total_completion_tokens"] == 100
+        assert sorted(sessions) == sorted(f"T{pid}:{game.run_id}" for pid in (477, 246))
+        assert sorted(p["task_id"] for p in prompts) == sorted(sessions)
+        assert sorted(p["payload"]["puzzle_id"] for p in prompts) == [246, 477]


### PR DESCRIPTION
Closes #23.

## What

`_run_puzzle_oneshot_ai` was modeled on `_run_puzzle_ai` and duplicated its scaffolding wholesale. That scaffolding is now a single shared exchange helper, parameterized by a per-mode verdict callback, exactly as the issue proposed:

| New | Owns |
|---|---|
| `_puzzle_context` / `_emit_puzzle_start` / `_emit_puzzle_finish` | model id, provider pinning, sticky-routing session, state moves |
| `_extract_content` | empty-content / reasoning-field fallback |
| `_accumulate_token_usage` | API vs approximate token accounting |
| `_run_exchange` | call model, account tokens/cost/cache/backoff, score via verdict callback, log exchange, emit telemetry; owns the API-error path (`API_ERROR` exchange, `model_response_error`, WIP to FAILED) and re-raises non-retryable errors |
| `_ExchangeTotals`, `_PuzzleRunContext`, `_Verdict`, `_Exchange`, `_OneshotOutcome` | shared state, kept per-invocation for thread safety |

The runners now hold only their game logic: the classic guess loop, and the one-shot parse-score-trap flow (`_score_oneshot_submission`). Also folded in two smaller duplications the one-shot interactive runner repeated (`_is_valid_oneshot_submission`, `_matched_group_colors`), and `_score_oneshot`'s inline structural gate now calls the former so scoring and the `ONESHOT_INVALID` marker can't drift apart.

## Constraints, and how they were verified

All four constraints from the issue hold.

**Byte-identical behavior** was verified with a golden-output harness that captures every `log_exchange`, `log_summary` and `controllog` call (kind, kwargs, payloads, field order) across 17 scenarios — classic perfect / mixed mistakes+invalid+loss / reasoning-field fallback / API error mid-run / missing-usage approximate tokens / cache+upstream cost / non-retryable abort, plus the one-shot equivalents and the trap, false-trap, N/A, partial and invalid cases. Output is identical before and after, including result strings, telemetry payloads and log key order.

**Downstream parsing** (`extract_summaries.py`, `generate_logs_view.py`) is unaffected: `ONESHOT_SCORE_S_GROUPS_G_TRAP_T_MAX_M`, `ONESHOT_INVALID_MAX_n` and the `ONESHOT_API_ERROR_MAX_n` mode marker are unchanged, and the marker still appears only in one-shot runs — a test asserts it does not leak into classic.

**Non-retryable propagation** is covered by tests using the real `InsufficientCreditsError` in both modes, sequential and parallel.

**Tests:** 146 passed (124 before). The 22 new tests in `TestSharedExchangeScaffolding` all pass against pre-refactor `core.py` too, so they describe behavior rather than the refactor — they cover totals across turns, exchange-log field order per mode, full controllog prompt/completion payloads, `NEW->WIP->DONE` / `WIP->FAILED` exactly once, no state move when the prompt build fails, backoff attribution, the per-puzzle MAX ceiling variants, and two-puzzle/two-thread context isolation.

## Review

Reviewed by Codex over two rounds. Round 1 caught a real ordering regression — the extracted helper emitted `NEW -> WIP` before the prompt was built, which could strand a task in `WIP`; fixed by splitting identifier resolution from the state-move emission and restoring the original order. Round 2 confirmed no production-path divergence and flagged three test blind spots (a `trap_groups or default` fallback that hid the `None` / `[]` cases, zero-backoff-only accounting assertions, and a "parallel" test running a single puzzle) plus the remaining `_score_oneshot` gate duplication — all addressed in the third commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
